### PR TITLE
INT-355_test_iq_server_dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,15 +34,17 @@ ENV IQ_SERVER_COOKBOOK_VERSION="release-0.2.0-01"
 ADD solo.json.erb /var/chef/solo.json.erb
 
 # Install using chef-solo
-RUN curl -L https://www.getchef.com/chef/install.sh | bash && \
-    /opt/chef/embedded/bin/erb /var/chef/solo.json.erb > /var/chef/solo.json && \
-    chef-solo --recipe-url https://github.com/sonatype/chef-nexus-iq-server/releases/download/${IQ_SERVER_COOKBOOK_VERSION}/chef-nexus-iq-server.tar.gz --json-attributes /var/chef/solo.json && \
-    rpm -qa *chef* | xargs rpm -e && \
-    rpm --rebuilddb && \
-    rm -rf /etc/chef && \
-    rm -rf /opt/chefdk && \
-    rm -rf /var/cache/yum && \
-    rm -rf /var/chef
+RUN curl -L https://www.getchef.com/chef/install.sh | bash \
+    && /opt/chef/embedded/bin/erb /var/chef/solo.json.erb > /var/chef/solo.json \
+    && chef-solo \
+       --recipe-url https://github.com/sonatype/chef-nexus-iq-server/releases/download/${IQ_SERVER_COOKBOOK_VERSION}/chef-nexus-iq-server.tar.gz \
+       --json-attributes /var/chef/solo.json \
+    && rpm -qa *chef* | xargs rpm -e \
+    && rpm --rebuilddb \
+    && rm -rf /etc/chef \
+    && rm -rf /opt/chefdk \
+    && rm -rf /var/cache/yum \
+    && rm -rf /var/chef
 
 VOLUME ${SONATYPE_WORK}
 

--- a/solo.json.erb
+++ b/solo.json.erb
@@ -36,7 +36,7 @@ raise RuntimeError, 'environment variable IQ_HOME is required' if ENV['IQ_HOME']
       }
     }
   },
-  'nexus_iq_server' => {
+  :nexus_iq_server => {
     :version => ENV['IQ_SERVER_VERSION'],
     :checksum => ENV['IQ_SERVER_SHA256'],
     :install_dir => ENV['IQ_HOME'],

--- a/spec/Dockerfile_spec.rb
+++ b/spec/Dockerfile_spec.rb
@@ -25,13 +25,12 @@ describe 'Dockerfile' do
     set :docker_image, @image.id
   end
 
-  it 'should generate a valid solo.json file' do
-    solo = JSON.parse(File.read('/var/chef/solo.json'))
-    expect(solo['run_list']).to eq([ 'recipe[nexus-iq-server::docker]' ])
+  it 'should remove solo.json during cleanup' do
+    expect(File).not_to exist('/var/chef/solo.json')
   end
 
   it 'should not have a chef package installed' do
-    expect(package("chef")).not_to be_installed
+    expect(package('chef')).not_to be_installed
   end
 
   it 'should have a user named nexus' do

--- a/spec/Dockerfile_spec.rb
+++ b/spec/Dockerfile_spec.rb
@@ -1,9 +1,21 @@
-# spec/Dockerfile_spec.rb
+# Copyright (c) 2017-present Sonatype, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-require "serverspec"
-require "docker"
+require 'serverspec'
+require 'docker'
 
-describe "Dockerfile" do
+describe 'Dockerfile' do
   before(:all) do
     Docker.options[:read_timeout] = 900
     @image = Docker::Image.build_from_dir('.')
@@ -13,20 +25,20 @@ describe "Dockerfile" do
     set :docker_image, @image.id
   end
 
-  it "should generate a valid solo.json file" do
+  it 'should generate a valid solo.json file' do
     solo = JSON.parse(File.read('/var/chef/solo.json'))
     expect(solo['run_list']).to eq([ 'recipe[nexus-iq-server::docker]' ])
   end
 
-  it "should not have a chef package installed" do
+  it 'should not have a chef package installed' do
     expect(package("chef")).not_to be_installed
   end
 
-  it "should have a user named nexus" do
+  it 'should have a user named nexus' do
     expect(user('nexus')).to exist
   end
 
-  it "should have a nexus java process running" do
+  it 'should have a nexus java process running' do
     expect(process('java')).to be_running
     expect(process('java')).to have_attributes(:user => 'nexus')
   end

--- a/spec/Dockerfile_spec.rb
+++ b/spec/Dockerfile_spec.rb
@@ -1,0 +1,33 @@
+# spec/Dockerfile_spec.rb
+
+require "serverspec"
+require "docker"
+
+describe "Dockerfile" do
+  before(:all) do
+    Docker.options[:read_timeout] = 900
+    @image = Docker::Image.build_from_dir('.')
+
+    set :os, family: :redhat
+    set :backend, :docker
+    set :docker_image, @image.id
+  end
+
+  it "should generate a valid solo.json file" do
+    solo = JSON.parse(File.read('/var/chef/solo.json'))
+    expect(solo['run_list']).to eq([ 'recipe[nexus-iq-server::docker]' ])
+  end
+
+  it "should not have a chef package installed" do
+    expect(package("chef")).not_to be_installed
+  end
+
+  it "should have a user named nexus" do
+    expect(user('nexus')).to exist
+  end
+
+  it "should have a nexus java process running" do
+    expect(process('java')).to be_running
+    expect(process('java')).to have_attributes(:user => 'nexus')
+  end
+end

--- a/spec/Dockerfile_spec.rb
+++ b/spec/Dockerfile_spec.rb
@@ -26,7 +26,7 @@ describe 'Dockerfile' do
   end
 
   it 'should remove solo.json during cleanup' do
-    expect(File).not_to exist('/var/chef/solo.json')
+    expect(file('/var/chef/solo.json')).not_to exist
   end
 
   it 'should not have a chef package installed' do


### PR DESCRIPTION
JIRA: https://issues.sonatype.org/browse/INT-355

I would prefer serverspec.org for testing docker images. It is essentially the same what we do for chef, but I found kitchen not to work very well with docker.

- serverspec does not need SSH in the docker container
- serverspec does not hijack the 'CMD' command to run its tests
- serverspec runs the tests inside the container