### PR TITLE
use support email instead of defunct cloud-ops

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 FROM registry.access.redhat.com/ubi8/ubi
 
 LABEL vendor=Sonatype \
-  maintainer="Sonatype <cloud-ops@sonatype.com>" \
+  maintainer="Sonatype <support@sonatype.com>" \
   com.sonatype.license="Apache License, Version 2.0" \
   com.sonatype.name="Nexus IQ Server image"
 

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -14,7 +14,7 @@
 
 FROM registry.access.redhat.com/ubi8/ubi
 
-MAINTAINER Sonatype <cloud-ops@sonatype.com>
+MAINTAINER Sonatype <support@sonatype.com>
 
 # Optional parameters.
 ARG IQ_SERVER_VERSION=1.90.0-01


### PR DESCRIPTION
cloud-ops@s.c. email bounces, so use support instead.