### PR TITLE
INT-2562 trigger red hat build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,10 @@ properties([
     string(defaultValue: '', description: 'New Nexus IQ Version', name: 'nexus_iq_version'),
     string(defaultValue: '', description: 'New Nexus IQ Version Sha256', name: 'nexus_iq_version_sha'),
 
-    string(defaultValue: '', description: 'New Nexus IQ Cookbook Version', name: 'nexus_iq_cookbook_version')
+    string(defaultValue: '', description: 'New Nexus IQ Cookbook Version', name: 'nexus_iq_cookbook_version'),
+    booleanParam(defaultValue: false, description: 'Skip Pushing of Docker Image and Tags', name: 'skip_push'),
+    booleanParam(defaultValue: false, description: 'Force Red Hat Certified Build for a non-master branch', name: 'force_red_hat_build'),
+    booleanParam(defaultValue: false, description: 'Skip Red Hat Certified Build', name: 'skip_red_hat_build'),
   ])
 ])
 
@@ -123,49 +126,60 @@ node('ubuntu-zion') {
         archiveArtifacts artifacts: "${archiveName}.tar.gz", onlyIfSuccessful: true
       }
     }
-    if (branch != 'master') {
-      return
-    }
-    stage('Push image') {
-      def dockerHubApiToken
-      withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'docker-hub-credentials',
-          usernameVariable: 'DOCKERHUB_API_USERNAME', passwordVariable: 'DOCKERHUB_API_PASSWORD']]) {
-        OsTools.runSafe(this, "docker tag ${imageId} ${organization}/${dockerHubRepository}:${version}")
-        OsTools.runSafe(this, "docker tag ${imageId} ${organization}/${dockerHubRepository}:latest")
-        OsTools.runSafe(this, """
-          docker login --username ${env.DOCKERHUB_API_USERNAME} --password ${env.DOCKERHUB_API_PASSWORD}
-        """)
-        OsTools.runSafe(this, "docker push ${organization}/${dockerHubRepository}")
 
-        response = OsTools.runSafe(this, """
-          curl -X POST https://hub.docker.com/v2/users/login/ \
-            -H 'cache-control: no-cache' -H 'content-type: application/json' \
-            -d '{ "username": "${env.DOCKERHUB_API_USERNAME}", "password": "${env.DOCKERHUB_API_PASSWORD}" }'
-        """)
-        token = readJSON text: response
-        dockerHubApiToken = token.token
+    if (branch == 'master' && ! params.skip_push) {
+      stage('Push image') {
+        def dockerHubApiToken
+        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'docker-hub-credentials',
+            usernameVariable: 'DOCKERHUB_API_USERNAME', passwordVariable: 'DOCKERHUB_API_PASSWORD']]) {
+          OsTools.runSafe(this, "docker tag ${imageId} ${organization}/${dockerHubRepository}:${version}")
+          OsTools.runSafe(this, "docker tag ${imageId} ${organization}/${dockerHubRepository}:latest")
+          OsTools.runSafe(this, """
+            docker login --username ${env.DOCKERHUB_API_USERNAME} --password ${env.DOCKERHUB_API_PASSWORD}
+          """)
+          OsTools.runSafe(this, "docker push ${organization}/${dockerHubRepository}")
 
-        def readme = readFile file: 'README.md', encoding: 'UTF-8'
-        readme = readme.replaceAll("(?s)<!--.*?-->", "")
-        readme = readme.replace("\"", "\\\"")
-        readme = readme.replace("\n", "\\n")
-        response = httpRequest customHeaders: [[name: 'authorization', value: "JWT ${dockerHubApiToken}"]],
-            acceptType: 'APPLICATION_JSON', contentType: 'APPLICATION_JSON', httpMode: 'PATCH',
-            requestBody: "{ \"full_description\": \"${readme}\" }",
-            url: "https://hub.docker.com/v2/repositories/${organization}/${dockerHubRepository}/"
+          response = OsTools.runSafe(this, """
+            curl -X POST https://hub.docker.com/v2/users/login/ \
+              -H 'cache-control: no-cache' -H 'content-type: application/json' \
+              -d '{ "username": "${env.DOCKERHUB_API_USERNAME}", "password": "${env.DOCKERHUB_API_PASSWORD}" }'
+          """)
+          token = readJSON text: response
+          dockerHubApiToken = token.token
+
+          def readme = readFile file: 'README.md', encoding: 'UTF-8'
+          readme = readme.replaceAll("(?s)<!--.*?-->", "")
+          readme = readme.replace("\"", "\\\"")
+          readme = readme.replace("\n", "\\n")
+          response = httpRequest customHeaders: [[name: 'authorization', value: "JWT ${dockerHubApiToken}"]],
+              acceptType: 'APPLICATION_JSON', contentType: 'APPLICATION_JSON', httpMode: 'PATCH',
+              requestBody: "{ \"full_description\": \"${readme}\" }",
+              url: "https://hub.docker.com/v2/repositories/${organization}/${dockerHubRepository}/"
+        }
+      }
+      stage('Push tags') {
+        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: credentialsId,
+                          usernameVariable: 'GITHUB_API_USERNAME', passwordVariable: 'GITHUB_API_PASSWORD']]) {
+          OsTools.runSafe(this, "git tag ${version}")
+          OsTools.runSafe(this, """
+            git push \
+            https://${env.GITHUB_API_USERNAME}:${env.GITHUB_API_PASSWORD}@github.com/${organization}/${gitHubRepository}.git \
+              ${version}
+          """)
+        }
+        OsTools.runSafe(this, "git tag -d ${version}")
       }
     }
-    stage('Push tags') {
-      withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: credentialsId,
-                        usernameVariable: 'GITHUB_API_USERNAME', passwordVariable: 'GITHUB_API_PASSWORD']]) {
-        OsTools.runSafe(this, "git tag ${version}")
-        OsTools.runSafe(this, """
-          git push \
-          https://${env.GITHUB_API_USERNAME}:${env.GITHUB_API_PASSWORD}@github.com/${organization}/${gitHubRepository}.git \
-            ${version}
-        """)
+
+    if ((! params.skip_red_hat_build) && (branch == 'master' || params.force_red_hat_build)) {
+      stage('Trigger Red Hat Certified Image Build') {
+        withCredentials([
+            string(credentialsId: 'docker-nexus-iq-rh-build-project-id', variable: 'PROJECT_ID'),
+            string(credentialsId: 'rh-build-service-api-key', variable: 'API_KEY')]) {
+          final redHatVersion = "${version}-ubi"
+          runGroovy('ci/TriggerRedHatBuild.groovy', [redHatVersion, PROJECT_ID, API_KEY].join(' '))
+        }
       }
-      OsTools.runSafe(this, "git tag -d ${version}")
     }
   } finally {
     OsTools.runSafe(this, "docker logout")

--- a/ci/TriggerRedHatBuild.groovy
+++ b/ci/TriggerRedHatBuild.groovy
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc. All rights reserved.
+ * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+
+/**
+ * This script triggers the build service for a certified docker image at Red Hat.
+ * It's meant to be used by Jenkins via the Jenkinsfile.
+ */
+@Grab('io.github.http-builder-ng:http-builder-ng-core:1.0.4')
+
+import groovyx.net.http.HttpBuilder
+import groovyx.net.http.HttpException
+
+if (args.size() < 3) {
+  System.err.println('Usage: groovy TriggerRedhatBuild.groovy <version> <projectId> <apiKey>')
+  System.exit(1)
+}
+
+new BuildClient(*args).run()
+
+class BuildClient {
+  private static final Integer TIMEOUT_MINUTES = 20
+
+  private final String version
+  private final String projectId
+
+  private final HttpBuilder builder
+
+  BuildClient(String version, String projectId, String apiKey) {
+    this.version = version
+    this.projectId = projectId
+
+    builder = HttpBuilder.configure {
+      request.uri = 'https://connect.redhat.com'
+      request.headers['Authorization'] = "Bearer ${apiKey}"
+      request.contentType = 'application/json'
+      request.body = [:]
+    }
+  }
+
+  /**
+   * fire off a series of requests to build and publish
+   * a container.
+   */
+  void run() {
+    final nextTag = getNextTag(version)
+    println "Triggering build as ${nextTag}"
+
+    final buildStatus = build(nextTag)
+
+    if (buildStatus.status != 'Created') {
+      fail(buildStatus)
+    }
+
+    final completedBuild = getCompletedBuild(nextTag)
+
+    if (completedBuild.failure) {
+      fail(completedBuild.failure)
+    }
+
+    final published = publish(completedBuild.digest, completedBuild.name)
+
+    if (published.failure) {
+      fail(published.failure)
+    }
+
+    println published
+  }
+
+  /**
+   * calculate the cutoff time in the future in miliseconds
+   * for comparison to System.currentTimeMillis()
+   * @param start start time in millis
+   * @param minutes minutes into the future
+   * @return future time in millis
+   */
+  private Long calcCutoffTime(Long start, Integer minutes) {
+    return minutes * 60 * 1000 + start
+  }
+
+  /**
+  * fail with message and exit with an error code for jenkins to see
+  * @param message message to print
+  */
+  private void fail(String message) {
+    System.err.println(message)
+    System.exit(1)
+  }
+
+
+  /**
+  * Request current version tags available at Red Hat.
+  * @return the list of all tags
+  */
+  private List getTags() {
+    return builder.post {
+      request.uri.path = "/api/v2/projects/${projectId}/tags"
+    }.tags
+  }
+
+  /**
+  * Request current version tags available at Red Hat,
+  * and calculate the next tag to use in this build.
+  * @param version the base version we're currently building
+  * @return the full new version string to submit for the next build
+  */
+  private String getNextTag(String version) {
+    final tags = getTags()*.name.collectMany {
+      it.split(', ').collect()
+    }
+
+    final currentIndex = tags.findAll {
+      it.startsWith(version)
+    }.collect {
+      it.replaceAll(/${version}-(\d+)-?.*/, '$1') as Integer
+    }.sort().reverse()[0]
+
+    final nextIndex =((currentIndex ?: 0) as Integer) + 1
+
+    return "${version}-${nextIndex}"
+  }
+
+  /**
+  * Trigger build of the certified image at Red Hat,
+  * @param nextTag the full version tag to be assigned to the new build
+  * @return the map from json with the status of the submitted build
+  */
+  private Map build(String nextTag) {
+    return builder.post {
+      request.uri.path = "/api/v2/projects/${projectId}/build"
+      request.body = [tag: nextTag]
+    }
+  }
+
+  /**
+  * Poll for the completed (built and scanned) build at Red Hat build service.
+  * @param nextTag the full version tag assigned to the new build
+  * @return the map from json with info about the completed build
+  */
+  private Map getCompletedBuild(String nextTag) {
+    final endTime = calcCutoffTime(System.currentTimeMillis(), TIMEOUT_MINUTES)
+
+    while (System.currentTimeMillis() < endTime) {
+      println 'Waiting for build to finish.'
+      sleep 60000
+
+      try {
+        final completedBuild = getTags().find {
+          it.name == nextTag && it.scan_status == 'passed'
+        }
+
+        if (completedBuild) {
+          return completedBuild
+        }
+      } catch (HttpException ex) {
+        ex.printStackTrace()
+        System.err.println "Failed retrieving completed builds, but still trying: ${ex.statusCode} [${ex.body}]"
+      }
+    }
+
+    return [failure: "TIMEOUT waiting for complete build: ${TIMEOUT_MINUTES} minutes"]
+  }
+
+  /**
+  * Trigger publishing of the new image at Red Hat build service.
+  * @param digest hash string that identifies the container to publish
+  * @param name tag name (version) of the container image to publish
+  * @return the map from json with status of the published container image
+  */
+  private Map publish(String digest, String name) {
+    final publishPath = [
+      '/api/v2/projects',
+      projectId,
+      'containers',
+      digest,
+      'tags',
+      name,
+      'publish'
+    ].join('/')
+
+    try {
+      return builder.post {
+        request.uri.path = publishPath
+      }
+    } catch (HttpException ex) {
+      ex.printStackTrace()
+      return [failure: "Failed to publish: ${ex.statusCode} [${ex.body}]"]
+    }
+  }
+}

--- a/ci/TriggerRedHatBuild.groovy
+++ b/ci/TriggerRedHatBuild.groovy
@@ -22,6 +22,7 @@ new BuildClient(*args).run()
 
 class BuildClient {
   private static final Integer TIMEOUT_MINUTES = 20
+  private static final Integer POLLING_SECONDS = 60
 
   private final String version
   private final String projectId
@@ -143,8 +144,8 @@ class BuildClient {
     final endTime = calcCutoffTime(System.currentTimeMillis(), TIMEOUT_MINUTES)
 
     while (System.currentTimeMillis() < endTime) {
-      println 'Waiting for build to finish.'
-      sleep 60000
+      println "Waiting for build to finish. Checking again in ${POLLING_SECONDS} seconds."
+      sleep(POLLING_SECONDS * 1000)
 
       try {
         final completedBuild = getTags().find {


### PR DESCRIPTION
When the IQ docker image is built, kick off the red hat certified build as well, just like NXRM 3.

JIRA: https://issues.sonatype.org/browse/INT-2562

Jenkins: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/docker-nexus-iq-server-feature/job/INT-2562-trigger-rh-build/3/
kicked off and built this red hat image: https://access.redhat.com/containers/#/registry.connect.redhat.com/sonatype/nexus-iq-server