### PR TITLE
CLM-15817 ; Add in scanning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,7 @@ node('ubuntu-zion') {
       credentialsId = 'integrations-github-api',
       imageName = 'sonatype/nexus-iq-server',
       archiveName = 'docker-nexus-iq-server',
+      iqApplicationId = 'docker-nexus-iq-server',
       dockerHubRepository = 'nexus-iq-server',
       tarName = 'docker-nexus-iq-server.tar'
   GitHub gitHub
@@ -108,13 +109,10 @@ node('ubuntu-zion') {
       OsTools.runSafe(this, "docker save ${imageName} -o ${env.WORKSPACE}/${tarName}")
       
       //decide which stage we are creating
-      def theStage = 'build'
-      if(branch == 'master') {
-        theStage = 'release'
-      }
+      def theStage = branch == 'master' ? 'release' : 'build'
 
       //run the evaluation
-      nexusPolicyEvaluation iqStage: "${theStage}", iqApplication: "${archiveName}",
+      nexusPolicyEvaluation iqStage: theStage, iqApplication: iqApplicationId,
         iqScanPatterns: [[scanPattern: '*.tar']],
         failBuildOnNetworkError: true
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,7 +106,7 @@ node('ubuntu-zion') {
       OsTools.runSafe(this, "docker save ${imageName} -o ${env.WORKSPACE}/${tarName}")
 
       nexusPolicyEvaluation
-        failBuildOnNextworkError: true,
+        failBuildOnNetworkError: true,
         iqApplication: 'docker-nexus-iq-server',
         iqScanPatterns: [[scanPattern: '*.tar']],
         iqStage: 'develop'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,8 @@ node('ubuntu-zion') {
       credentialsId = 'integrations-github-api',
       imageName = 'sonatype/nexus-iq-server',
       archiveName = 'docker-nexus-iq-server',
-      dockerHubRepository = 'nexus-iq-server'
+      dockerHubRepository = 'nexus-iq-server',
+      tarName = 'docker-nexus-iq-server.tar'
   GitHub gitHub
 
   try {
@@ -101,6 +102,16 @@ node('ubuntu-zion') {
         gitHub.statusUpdate commitId, 'success', 'test', 'Tests succeeded'
       }
     }
+    stage('Evaluate') {
+      OsTools.runSafe(this, "docker save ${imageName} -o ${env.WORKSPACE}/${tarName}")
+
+      nexusPolicyEvaluation
+        failBuildOnNextworkError: true,
+        iqApplication: 'docker-nexus-iq-server',
+        iqScanPatterns: [[scanPattern: '*.tar']],
+        iqStage: 'develop'
+    }
+
     if (currentBuild.result == 'FAILURE') {
       return
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,7 +109,7 @@ node('ubuntu-zion') {
       OsTools.runSafe(this, "docker save ${imageName} -o ${env.WORKSPACE}/${tarName}")
       
       //decide which stage we are creating
-      def theStage = branch == 'master' ? (params.push_image ? 'release' : 'stage') : 'build'
+      def theStage = branch == 'master' ? (params.push_image ? 'release' : 'stage-release') : 'build'
 
       //run the evaluation
       nexusPolicyEvaluation iqStage: theStage, iqApplication: iqApplicationId,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,11 +105,9 @@ node('ubuntu-zion') {
     stage('Evaluate') {
       OsTools.runSafe(this, "docker save ${imageName} -o ${env.WORKSPACE}/${tarName}")
 
-      nexusPolicyEvaluation
-        failBuildOnNetworkError: true,
-        iqApplication: 'docker-nexus-iq-server',
+      nexusPolicyEvaluation iqStage: 'develop', iqApplication: "${archiveName}",
         iqScanPatterns: [[scanPattern: '*.tar']],
-        iqStage: 'develop'
+        failBuildOnNetworkError: true
     }
 
     if (currentBuild.result == 'FAILURE') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,9 +103,18 @@ node('ubuntu-zion') {
       }
     }
     stage('Evaluate') {
+      
+      //Create tar of our image
       OsTools.runSafe(this, "docker save ${imageName} -o ${env.WORKSPACE}/${tarName}")
+      
+      //decide which stage we are creating
+      def theStage = 'build'
+      if(branch == 'master') {
+        theStage = 'release'
+      }
 
-      nexusPolicyEvaluation iqStage: 'develop', iqApplication: "${archiveName}",
+      //run the evaluation
+      nexusPolicyEvaluation iqStage: "${theStage}", iqApplication: "${archiveName}",
         iqScanPatterns: [[scanPattern: '*.tar']],
         failBuildOnNetworkError: true
     }


### PR DESCRIPTION
This PR adds in an IQ evaluation into the docker pipeline.

+ `build` stage for non-master builds
+ `stage-release` stage for master but not pushing
+ `release` stage for master builds (since master builds ship to docker hub)

This also changes `skip_push` to be `push_image` and is false by default which is a change in behavior