### PR TITLE
Avoid committing the saved image tar when releasing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .idea/
 Berksfile.lock
+build/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,7 +114,7 @@ node('ubuntu-zion') {
 
         //run the evaluation
         nexusPolicyEvaluation iqStage: theStage, iqApplication: iqApplicationId,
-          iqScanPatterns: [[scanPattern: '*.tar']],
+          iqScanPatterns: [[scanPattern: 'build/*.tar']],
           failBuildOnNetworkError: true
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,15 +106,17 @@ node('ubuntu-zion') {
     stage('Evaluate') {
       
       //Create tar of our image
-      OsTools.runSafe(this, "docker save ${imageName} -o ${env.WORKSPACE}/${tarName}")
+      dir('build') {
+        OsTools.runSafe(this, "docker save ${imageName} -o ${tarName}")
       
-      //decide which stage we are creating
-      def theStage = branch == 'master' ? (params.push_image ? 'release' : 'stage-release') : 'build'
+        //decide which stage we are creating
+        def theStage = branch == 'master' ? (params.push_image ? 'release' : 'stage-release') : 'build'
 
-      //run the evaluation
-      nexusPolicyEvaluation iqStage: theStage, iqApplication: iqApplicationId,
-        iqScanPatterns: [[scanPattern: '*.tar']],
-        failBuildOnNetworkError: true
+        //run the evaluation
+        nexusPolicyEvaluation iqStage: theStage, iqApplication: iqApplicationId,
+          iqScanPatterns: [[scanPattern: '*.tar']],
+          failBuildOnNetworkError: true
+      }
     }
 
     if (currentBuild.result == 'FAILURE') {


### PR DESCRIPTION
We can't deploy at the moment
https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/docker-nexus-iq-server/84/console
```
git add .
+ git commit -m Update IQ Server to 1.92.0-02. Update IQ Cookbook to release-0.4.20200528-184754.b6efb6d.
+ git push https://****:****@github.com/sonatype/docker-nexus-iq-server.git master
remote: error: GH001: Large files detected. You may want to try Git Large File Storage - https://git-lfs.github.com.        
remote: error: Trace: 3c143e016fb1f09ff2ed3cd3f33cb4e3        
remote: error: See http://git.io/iEPt8g for more information.        
remote: error: File docker-nexus-iq-server.tar is 560.14 MB; this exceeds GitHub's file size limit of 100.00 MB        
To https://github.com/sonatype/docker-nexus-iq-server.git
 ! [remote rejected] master -> master (pre-receive hook declined)
error: failed to push some refs to 'https://****:****@github.com/sonatype/docker-nexus-iq-server.git'
[master 27cda5f] Update IQ Server to 1.92.0-02. Update IQ Cookbook to release-0.4.20200528-184754.b6efb6d.
 3 files changed, 8 insertions(+), 8 deletions(-)
 create mode 100644 docker-nexus-iq-server.tar
```

we suspect this is because it is trying to commit the docker image we saved to use for scanning