### PR TITLE
CLM-16955 IQ Docker make logs persistent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ RUN chown -R nexus:nexus ${IQ_HOME} \
 
 # This is where we will store persistent data
 VOLUME ${SONATYPE_WORK}
+VOLUME ${LOGS_HOME}
 
 # Expose the ports
 EXPOSE 8070

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -101,6 +101,7 @@ RUN chown -R nexus:nexus ${IQ_HOME} \
 
 # This is where we will store persistent data
 VOLUME ${SONATYPE_WORK}
+VOLUME ${LOGS_HOME}
 
 # Expose the ports
 EXPOSE 8070

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ for additional information.
   ```
   $ docker volume create --name sonatype-work
   $ docker volume create --name sonatype-logs
-  $ docker run -d -p 8070:8070 -p 8071:8071 --name nexus-iq-server -v sonatype-work:/sonatype-work -v sonatype-logs:var/log/nexus-iq-server sonatype/nexus-iq-server
+  $ docker run -d -p 8070:8070 -p 8071:8071 --name nexus-iq-server -v sonatype-work:/sonatype-work -v sonatype-logs:/var/log/nexus-iq-server sonatype/nexus-iq-server
   ```
 
   2. *Mount a host directory as the volume*.  This is not portable, as it

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ for additional information.
 
   ```
   $ docker volume create --name sonatype-work
-  $ docker run -d -p 8070:8070 -p 8071:8071 --name nexus-iq-server -v sonatype-work:/sonatype-work sonatype/nexus-iq-server
+  $ docker volume create --name sonatype-logs
+  $ docker run -d -p 8070:8070 -p 8071:8071 --name nexus-iq-server -v sonatype-work:/sonatype-work -v sonatype-logs:var/log/nexus-iq-server sonatype/nexus-iq-server
   ```
 
   2. *Mount a host directory as the volume*.  This is not portable, as it
@@ -87,7 +88,8 @@ for additional information.
 
   ```
   $ mkdir /some/dir/sonatype-work
-  $ docker run -d -p 8070:8070 -p 8071:8071 --name nexus-iq-server -v /some/dir/sonatype-work:/sonatype-work sonatype/nexus-iq-server
+  $ mkdir /some/dir/sonatype-logs
+  $ docker run -d -p 8070:8070 -p 8071:8071 --name nexus-iq-server -v /some/dir/sonatype-work:/sonatype-work -v /some/dir/sonatype-logs:/var/log/nexus-iq-server sonatype/nexus-iq-server
   ```
   
 ## Running

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The following optional variables can be used when building the image:
 - IQ_SERVER_VERSION: Version of Nexus IQ Server
 - IQ_SERVER_SHA256: Check hash matches the downloaded IQ Server archive or else fail build. Required if `IQ_SERVER_VERSION` is provided.
 - SONATYPE_WORK: Path to Nexus IQ Server working directory where variable data is stored
+- LOGS_HOME: Path to Nexus IQ Server directory where logs are stored
 
 ### Customizing the Default config.yml
 


### PR DESCRIPTION
Jira: https://issues.sonatype.org/browse/CLM-16955
Jenkins: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/docker-nexus-iq-server-feature/job/CLM-16955-persist-logs/

So the Jira mentions moving the logs (clm-server.log and request.log files) from the `/var/log/nexus-iq` into the `/sonatype-work` directory so they are persisted and available after container restarts.

This is an alternative approach of instead making the logs directory `/var/log/nexus-iq` persistence. I'd like people's thoughts on 
1. Is this a preferable solution and 
2. The approach taken is correct.