### PR TITLE
lose the microdnf update to allow the release to continue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,7 @@ LABEL vendor=Sonatype \
 USER root
 
 # For testing
-RUN microdnf update \
-&& microdnf install procps
+RUN microdnf install procps
 
 # Create folders
 RUN mkdir -p ${TEMP} \

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -50,8 +50,7 @@ LABEL name="Nexus IQ Server image" \
 USER root
 
 # For testing
-RUN microdnf update \
-&& microdnf install procps
+RUN microdnf install procps
 
 # Create folders
 RUN mkdir -p ${TEMP} \


### PR DESCRIPTION
it was causing an rpmlib conflict during build.
```
Step 12/27 : RUN microdnf update && microdnf install procps
 ---> Running in 378049d56ac2

(microdnf:6): librhsm-WARNING **: 18:32:21.219: Found 0 entitlement certificates

(microdnf:6): librhsm-WARNING **: 18:32:21.220: Found 0 entitlement certificates
Downloading metadata...
Downloading metadata...
Downloading metadata...
error: Could not depsolve transaction; 2 problems detected:
 Problem 1: cannot install both rpm-libs-4.14.3-4.el8.x86_64 and rpm-libs-4.14.2-37.el8.x86_64
  - package rpm-plugin-systemd-inhibit-4.14.2-37.el8.x86_64 requires rpm-libs(x86-64) = 4.14.2-37.el8, but none of the providers can be installed
  - cannot install the best update candidate for package rpm-libs-4.14.2-37.el8.x86_64
  - problem with installed package rpm-plugin-systemd-inhibit-4.14.2-37.el8.x86_64
 Problem 2: cannot install both rpm-libs-4.14.3-4.el8.x86_64 and rpm-libs-4.14.2-37.el8.x86_64
  - package rpm-plugin-systemd-inhibit-4.14.2-37.el8.x86_64 requires rpm-libs(x86-64) = 4.14.2-37.el8, but none of the providers can be installed
  - package python3-rpm-4.14.3-4.el8.x86_64 requires rpm-libs(x86-64) = 4.14.3-4.el8, but none of the providers can be installed
  - cannot install the best update candidate for package rpm-plugin-systemd-inhibit-4.14.2-37.el8.x86_64
  - cannot install the best update candidate for package python3-rpm-4.14.2-37.el8.x86_64
The command '/bin/sh -c microdnf update && microdnf install procps' returned a non-zero code: 1
```

failing master build that exhibits the problem: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/docker-nexus-iq-server/100/

fixed build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/docker-nexus-iq-server-feature/job/mitigate-rpm-failure/