### PR TITLE
update latest packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ LABEL vendor=Sonatype \
 USER root
 
 # For testing
-RUN microdnf install procps
+RUN dnf update --allowerasing -y \
+&& dnf install -y procps
 
 # Create folders
 RUN mkdir -p ${TEMP} \

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -50,7 +50,8 @@ LABEL name="Nexus IQ Server image" \
 USER root
 
 # For testing
-RUN microdnf install procps
+RUN dnf update --allowerasing -y \
+&& dnf install -y procps
 
 # Create folders
 RUN mkdir -p ${TEMP} \


### PR DESCRIPTION
while removing chef, a `microdnf update` was newly introduced, but that caused some conflicts between versions of rpm-lib, and blocked the build. we eliminated the update to proceed there, but having latest packages could be nice, so this brings back an update that wortks.

build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/docker-nexus-iq-server-feature/job/update-latest-packages/