### PR TITLE
Specify uid and gid to prevent need to migrate ownership on base image change - CLM-17312

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,8 @@ RUN cd ${TEMP} \
 && rm -rf ${TEMP}
 
 # Add group and user
-RUN groupadd nexus \
-&& adduser -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false -r nexus
+RUN groupadd -g 1000 nexus \
+&& adduser -u 997 -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false -r nexus
 
 # Change owner to nexus user
 RUN chown -R nexus:nexus ${IQ_HOME} \

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -79,8 +79,8 @@ RUN cd ${TEMP} \
 && rm -rf ${TEMP}
 
 # Add group and user
-RUN groupadd nexus \
-&& adduser -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false -r nexus
+RUN groupadd -g 1000 nexus \
+&& adduser -u 997 -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false -r nexus
 
 # Red Hat Certified Container commands
 COPY rh-docker /


### PR DESCRIPTION
Bug: https://issues.sonatype.org/browse/CLM-17312

Starting IQ 101 via
`docker run -d -p 8070:8070 -p 8071:8071 --name nexus-iq-server sonatype/nexus-iq-server:1.101.0`

And checking the uid of the `nexus` user and the gid of the `nexus` group gives
```
id nexus
uid=997(nexus) gid=1000(nexus) groups=1000(nexus)
```
This PR specifically sets them to these values, which should prevent needing to take ownership of existing volumes when migrating in the future if the base image changes