### PR TITLE
Update docs with workaround for missing JAVA_OPTS in 101 and 102 - CLM-17416

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ $ docker run -d -p 8070:8070 -p 8071:8071 --name nexus-iq-server -e \
   JAVA_OPTS="-Ddw.logging.level=TRACE" sonatype/nexus-iq-server
 ```
 
+### Runtime Server Configuration for Versions 101 and 102
+
+Note that for version 101 and 102 `${JAVA_OPTS}` is missing from the startup script `start.sh` and so,
+in addition to your command modifying the `JAVA_OPTS` environment variable (similar to the above), you must also run
+```
+docker exec nexus-iq-server sed -i 's/java/java \${JAVA_OPTS}/g' /opt/sonatype/nexus-iq-server/start.sh
+docker restart nexus-iq-server
+```
+
 ## Persistent Data
 
 There are two general approaches to handling persistent storage requirements


### PR DESCRIPTION
Bug: https://issues.sonatype.org/browse/CLM-17416
Originally spotted in: https://github.com/sonatype/docker-nexus-iq-server/pull/53
Fixed for 103+ in: https://github.com/sonatype/docker-nexus-iq-server/commit/af5db6f15195c0e6c6d84f83dcff80ac85edda96