### PR TITLE
Reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,12 +36,14 @@ USER root
 RUN dnf update --allowerasing -y \
 && dnf install -y procps
 
-# Create folders
+# Create folders, add group and user
 RUN mkdir -p ${TEMP} \
 && mkdir -m 0755 -p ${IQ_HOME} \
 && mkdir -m 0755 -p ${SONATYPE_WORK} \
 && mkdir -m 0755 -p ${CONFIG_HOME} \
-&& mkdir -m 0755 -p ${LOGS_HOME}
+&& mkdir -m 0755 -p ${LOGS_HOME} \
+&& groupadd -g 1000 nexus \
+&& adduser -u 997 -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false -r nexus
 
 # Copy config.yml and set sonatypeWork to the correct value
 COPY config.yml ${TEMP}
@@ -60,14 +62,8 @@ RUN cd ${TEMP} \
 && tar -xvf nexus-iq-server-${IQ_SERVER_VERSION}-bundle.tar.gz \
 && mv nexus-iq-server-${IQ_SERVER_VERSION}.jar ${IQ_HOME} \
 && cd ${IQ_HOME} \
-&& rm -rf ${TEMP}
-
-# Add group and user
-RUN groupadd -g 1000 nexus \
-&& adduser -u 997 -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false -r nexus
-
-# Change owner to nexus user
-RUN chown -R nexus:nexus ${IQ_HOME} \
+&& rm -rf ${TEMP} \
+&& chown -R nexus:nexus ${IQ_HOME} \
 && chown -R nexus:nexus ${SONATYPE_WORK} \
 && chown -R nexus:nexus ${CONFIG_HOME} \
 && chown -R nexus:nexus ${LOGS_HOME}

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -53,12 +53,14 @@ USER root
 RUN dnf update --allowerasing -y \
 && dnf install -y procps
 
-# Create folders
+# Create folders, add group and user
 RUN mkdir -p ${TEMP} \
 && mkdir -m 0755 -p ${IQ_HOME} \
 && mkdir -m 0755 -p ${SONATYPE_WORK} \
 && mkdir -m 0755 -p ${CONFIG_HOME} \
-&& mkdir -m 0755 -p ${LOGS_HOME}
+&& mkdir -m 0755 -p ${LOGS_HOME} \
+&& groupadd -g 1000 nexus \
+&& adduser -u 997 -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false -r nexus
 
 # Copy config.yml and set sonatypeWork to the correct value
 COPY config.yml ${TEMP}
@@ -77,11 +79,11 @@ RUN cd ${TEMP} \
 && tar -xvf nexus-iq-server-${IQ_SERVER_VERSION}-bundle.tar.gz \
 && mv nexus-iq-server-${IQ_SERVER_VERSION}.jar ${IQ_HOME} \
 && cd ${IQ_HOME} \
-&& rm -rf ${TEMP}
-
-# Add group and user
-RUN groupadd -g 1000 nexus \
-&& adduser -u 997 -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false -r nexus
+&& rm -rf ${TEMP} \
+&& chown -R nexus:nexus ${IQ_HOME} \
+&& chown -R nexus:nexus ${SONATYPE_WORK} \
+&& chown -R nexus:nexus ${CONFIG_HOME} \
+&& chown -R nexus:nexus ${LOGS_HOME}
 
 # Red Hat Certified Container commands
 COPY rh-docker /
@@ -92,12 +94,6 @@ RUN usermod -a -G root nexus \
 && chmod 0755 /uid_template.sh \
 && bash /uid_template.sh \
 && chmod 0664 /etc/passwd
-
-# Change owner to nexus user
-RUN chown -R nexus:nexus ${IQ_HOME} \
-&& chown -R nexus:nexus ${SONATYPE_WORK} \
-&& chown -R nexus:nexus ${CONFIG_HOME} \
-&& chown -R nexus:nexus ${LOGS_HOME}
 
 # This is where we will store persistent data
 VOLUME ${SONATYPE_WORK}


### PR DESCRIPTION
looking at compressed image size on DockerHub https://hub.docker.com/r/sonatype/nexus-iq-server/tags?page=1&ordering=last_updated
- release 100: 273.32 MB
- release 101: 383.21 MB
- release 102: 523.75 MB

Found 2 causes:
1. nexus-iq-server.jar (~130 MB) is stored twice because chown is done in a separate RUN
2. while installing procps, there is also an update of packages, which brings in a new release of OpenJDK