### PR TITLE
Fix location of audit.log

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -22,6 +22,12 @@ logging:
     org.eclipse.birt.report.engine.layout.pdf.font.FontConfigReader: WARN
     org.eclipse.jetty: INFO
     org.apache.shiro.web.filter.authc.BasicHttpAuthenticationFilter: INFO
+    com.sonatype.insight.audit:
+      appenders:
+      - type: file
+        currentLogFilename: "/var/log/nexus-iq-server/audit.log"
+        archivedLogFilenamePattern: "/var/log/nexus-iq-server/audit-%d.log.gz"
+        archivedFileCount: 50
   appenders:
   - type: console
     threshold: INFO


### PR DESCRIPTION
https://issues.sonatype.org/browse/CLM-17366

By the default configuration, the audit log is created at `./log/audit.log` which for the docker image translates to `/opt/sonatype/nexus-iq-server/log/audit.log`. However, the log files are expected to reside in `/var/log/nexus-iq-server/`, so these changes explicitly configure that location for the audit log as well.