### PR TITLE
Health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,9 @@ VOLUME ${LOGS_HOME}
 EXPOSE 8070
 EXPOSE 8071
 
+# Configure health check for app port
+HEALTHCHECK CMD curl --fail http://localhost:8070/ || exit 1
+
 # Change to nexus user
 USER nexus
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/CLM-17495

As background:
- https://docs.docker.com/engine/reference/builder/#healthcheck
- https://curl.se/docs/manpage.html#-f

Unlike suggested in JIRA, this here pings the main port which is a more relevant indicator of the app's health. `--fail` tells curl to signal HTTP errors via its exit code which `|| exit 1` converts from 22 to 1 to comply with the Docker spec.

