### PR TITLE
Remove DOCKER_TYPE environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,6 @@ ARG SONATYPE_WORK="/sonatype-work"
 ARG CONFIG_HOME="/etc/nexus-iq-server"
 ARG LOGS_HOME="/var/log/nexus-iq-server"
 
-ENV DOCKER_TYPE="docker"
-
 LABEL vendor=Sonatype \
   maintainer="Sonatype <support@sonatype.com>" \
   com.sonatype.license="Apache License, Version 2.0" \

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -23,8 +23,6 @@ ARG SONATYPE_WORK="/sonatype-work"
 ARG CONFIG_HOME="/etc/nexus-iq-server"
 ARG LOGS_HOME="/var/log/nexus-iq-server"
 
-ENV DOCKER_TYPE="rh-docker"
-
 MAINTAINER Sonatype <support@sonatype.com>
 
 LABEL name="Nexus IQ Server image" \


### PR DESCRIPTION
It's my understanding that this environment variable only existed to allow the selection of the proper Chef recipe in https://github.com/sonatype/docker-nexus-iq-server/commit/6eeb86494455226717b90897d8604f33ff975d8d#diff-0eed21d6b4c3636313618510df859c85839e36d1873bf851455d31525ca69cfbL24 (solo.json.erb)
Hence with the removal of Chef, the variable is superfluous complexity.