### PR TITLE
docker push --all-tags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,7 +147,7 @@ node('ubuntu-zion') {
           OsTools.runSafe(this, """
             docker login --username ${env.DOCKERHUB_API_USERNAME} --password ${env.DOCKERHUB_API_PASSWORD}
           """)
-          OsTools.runSafe(this, "docker push ${organization}/${dockerHubRepository}")
+          OsTools.runSafe(this, "docker push --all-tags ${organization}/${dockerHubRepository}")
 
           response = OsTools.runSafe(this, """
             curl -X POST https://hub.docker.com/v2/users/login/ \


### PR DESCRIPTION
Docker seems to have recently changed to only push most recent tag by default.
This applies the same wisdom found in https://github.com/sonatype/docker-nexus3/pull/127/files