### PR TITLE
INT-4824 Temporarily pin upstream image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/openjdk-8
+FROM registry.access.redhat.com/ubi8/openjdk-8:1.3-8
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.107.0-01

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/openjdk-8
+FROM registry.access.redhat.com/ubi8/openjdk-8:1.3-8
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.107.0-01


### PR DESCRIPTION
#### Description

Pins version due to a bug in the redhat image (see jira ticket)

#### Links
Jira: https://issues.sonatype.org/browse/INT-4824
Jenkins: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/docker-nexus-iq-server-feature/job/INT-4824_temporarily_pin_version/