### PR TITLE
Added optional build arguments CLM-17772

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
 ARG SONATYPE_WORK="/sonatype-work"
 ARG CONFIG_HOME="/etc/nexus-iq-server"
 ARG LOGS_HOME="/var/log/nexus-iq-server"
+ARG GID=1000
+ARG UID=997
 
 LABEL name="Nexus IQ Server image" \
   maintainer="Sonatype <support@sonatype.com>" \
@@ -76,8 +78,8 @@ RUN cd ${TEMP} \
 && rm -rf ${TEMP} \
 \
 # Add group and user
-&& groupadd -g 1000 nexus \
-&& adduser -u 997 -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false -r nexus \
+&& groupadd -g ${GID} nexus \
+&& adduser -u ${UID} -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false -r nexus \
 \
 # Change owner to nexus user
 && chown -R nexus:nexus ${IQ_HOME} \

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -22,6 +22,8 @@ ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
 ARG SONATYPE_WORK="/sonatype-work"
 ARG CONFIG_HOME="/etc/nexus-iq-server"
 ARG LOGS_HOME="/var/log/nexus-iq-server"
+ARG GID=1000
+ARG UID=997
 
 LABEL name="Nexus IQ Server image" \
   maintainer="Sonatype <support@sonatype.com>" \
@@ -76,8 +78,8 @@ RUN cd ${TEMP} \
 && rm -rf ${TEMP} \
 \
 # Add group and user
-&& groupadd -g 1000 nexus \
-&& adduser -u 997 -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false -r nexus \
+&& groupadd -g ${GID} nexus \
+&& adduser -u ${UID} -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false -r nexus \
 \
 # Change owner to nexus user
 && chown -R nexus:nexus ${IQ_HOME} \

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ The following optional variables can be used when building the image:
 - IQ_SERVER_SHA256: Check hash matches the downloaded IQ Server archive or else fail build. Required if `IQ_SERVER_VERSION` is provided.
 - SONATYPE_WORK: Path to Nexus IQ Server working directory where variable data is stored
 - LOGS_HOME: Path to Nexus IQ Server directory where logs are stored
+- GID: GID of the user group used when running the image
+- UID: UID of the user used when running the image
 
 ### Customizing the Default config.yml
 


### PR DESCRIPTION
Jira: https://issues.sonatype.org/browse/CLM-17772

Two optional build arguments have been added, `UID` and `GID`. They allow the user to override the default user and/or group that are used when running the image.

These arguments can be used as follows:
```
docker build --build-arg UID=1000 --build-arg GID=1000 -t nexus-iq-server . 
```

Using these arguments when building the image, will prevent the "Permission denied" error  when running the container (as described in the description of [CLM-17772](https://issues.sonatype.org/browse/CLM-17772)).