### PR TITLE
CLM-18632: modify user and remove -r flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG SONATYPE_WORK="/sonatype-work"
 ARG CONFIG_HOME="/etc/nexus-iq-server"
 ARG LOGS_HOME="/var/log/nexus-iq-server"
 ARG GID=1000
-ARG UID=997
+ARG UID=1000
 
 LABEL name="Nexus IQ Server image" \
   maintainer="Sonatype <support@sonatype.com>" \
@@ -79,7 +79,7 @@ RUN cd ${TEMP} \
 \
 # Add group and user
 && groupadd -g ${GID} nexus \
-&& adduser -u ${UID} -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false -r nexus \
+&& adduser -u ${UID} -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false nexus \
 \
 # Change owner to nexus user
 && chown -R nexus:nexus ${IQ_HOME} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@
 FROM registry.access.redhat.com/ubi8/openjdk-8:1.3-8
 
 # Build parameters
-ARG IQ_SERVER_VERSION=1.116.0-01
-ARG IQ_SERVER_SHA256=4463213916bd935bb0c9f33fbcf59b6af0d7fc13a362ba0cb2041a1be30c6330
+ARG IQ_SERVER_VERSION=1.117.0-01
+ARG IQ_SERVER_SHA256=370a613c1eec34c7e22cf90550247c94076dbd427a895b4a9e546a903e54b307
 ARG TEMP="/tmp/work"
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
 ARG SONATYPE_WORK="/sonatype-work"
@@ -29,7 +29,7 @@ LABEL name="Nexus IQ Server image" \
   maintainer="Sonatype <support@sonatype.com>" \
   vendor=Sonatype \
   version="${IQ_SERVER_VERSION}" \
-  release="1.116.0" \
+  release="1.117.0" \
   url="https://www.sonatype.com" \
   summary="The Nexus IQ Server" \
   description="Nexus IQ Server is a policy engine powered by precise intelligence on open source components. \

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -23,7 +23,7 @@ ARG SONATYPE_WORK="/sonatype-work"
 ARG CONFIG_HOME="/etc/nexus-iq-server"
 ARG LOGS_HOME="/var/log/nexus-iq-server"
 ARG GID=1000
-ARG UID=997
+ARG UID=1000
 
 LABEL name="Nexus IQ Server image" \
   maintainer="Sonatype <support@sonatype.com>" \
@@ -79,7 +79,7 @@ RUN cd ${TEMP} \
 \
 # Add group and user
 && groupadd -g ${GID} nexus \
-&& adduser -u ${UID} -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false -r nexus \
+&& adduser -u ${UID} -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false nexus \
 \
 # Change owner to nexus user
 && chown -R nexus:nexus ${IQ_HOME} \

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -15,8 +15,8 @@
 FROM registry.access.redhat.com/ubi8/openjdk-8:1.3-8
 
 # Build parameters
-ARG IQ_SERVER_VERSION=1.116.0-01
-ARG IQ_SERVER_SHA256=4463213916bd935bb0c9f33fbcf59b6af0d7fc13a362ba0cb2041a1be30c6330
+ARG IQ_SERVER_VERSION=1.117.0-01
+ARG IQ_SERVER_SHA256=370a613c1eec34c7e22cf90550247c94076dbd427a895b4a9e546a903e54b307
 ARG TEMP="/tmp/work"
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
 ARG SONATYPE_WORK="/sonatype-work"
@@ -29,7 +29,7 @@ LABEL name="Nexus IQ Server image" \
   maintainer="Sonatype <support@sonatype.com>" \
   vendor=Sonatype \
   version="${IQ_SERVER_VERSION}" \
-  release="1.116.0" \
+  release="1.117.0" \
   url="https://www.sonatype.com" \
   summary="The Nexus IQ Server" \
   description="Nexus IQ Server is a policy engine powered by precise intelligence on open source components. \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,6 @@ properties([
     string(defaultValue: '', description: 'New Nexus IQ Version Sha256', name: 'nexus_iq_version_sha'),
 
     booleanParam(defaultValue: false, description: 'Push Docker Image and Tags', name: 'push_image'),
-    booleanParam(defaultValue: false, description: 'Force Red Hat Certified Build for a non-master branch', name: 'force_red_hat_build'),
-    booleanParam(defaultValue: false, description: 'Skip Red Hat Certified Build', name: 'skip_red_hat_build'),
   ])
 ])
 
@@ -182,16 +180,6 @@ node('ubuntu-zion') {
       }
     }
 
-    if ((! params.skip_red_hat_build) && (branch == 'master' || params.force_red_hat_build)) {
-      stage('Trigger Red Hat Certified Image Build') {
-        withCredentials([
-            string(credentialsId: 'docker-nexus-iq-rh-build-project-id', variable: 'PROJECT_ID'),
-            string(credentialsId: 'rh-build-service-api-key', variable: 'API_KEY')]) {
-          final redHatVersion = "${version}-ubi"
-          runGroovy('ci/TriggerRedHatBuild.groovy', [redHatVersion, PROJECT_ID, API_KEY].join(' '))
-        }
-      }
-    }
   } finally {
     OsTools.runSafe(this, "docker logout")
     OsTools.runSafe(this, "docker system prune -a -f")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ node('ubuntu-zion') {
   def commitId, commitDate, version, imageId, branch, dockerFileLocations
   def organization = 'sonatype',
       gitHubRepository = 'docker-nexus-iq-server',
-      credentialsId = 'integrations-github-api',
+      credentialsId = 'sonaype-ci-github-access-token',
       imageName = 'sonatype/nexus-iq-server',
       archiveName = 'docker-nexus-iq-server',
       iqApplicationId = 'docker-nexus-iq-server',
@@ -115,7 +115,7 @@ node('ubuntu-zion') {
     }
     if (params.nexus_iq_version && params.nexus_iq_version_sha) {
       stage('Commit IQ Version Update') {
-        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'integrations-github-api',
+        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: credentialsId,
                         usernameVariable: 'GITHUB_API_USERNAME', passwordVariable: 'GITHUB_API_PASSWORD']]) {
           def commitMessage = [
             params.nexus_iq_version && params.nexus_iq_version_sha ? "Update IQ Server to ${params.nexus_iq_version}." : "",

--- a/Jenkinsfile.rh
+++ b/Jenkinsfile.rh
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017-present Sonatype, Inc. All rights reserved.
+ * Includes the third-party code listed at http://links.sonatype.com/products/nexus/attributions.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+@Library(['private-pipeline-library', 'jenkins-shared']) _
+import com.sonatype.jenkins.pipeline.OsTools
+
+node('ubuntu-zion') {
+  def version
+  def credentialsId = 'integrations-github-api'
+
+  try {
+    stage('Preparation') {
+      deleteDir()
+
+      def checkoutDetails = checkout scm
+
+      checkoutDetails.GIT_BRANCH == 'origin/master' ? 'master' : checkoutDetails.GIT_BRANCH
+
+      version = readVersion()
+    }
+    stage('Trigger Red Hat Certified Image Build') {
+        withCredentials([
+            string(credentialsId: 'docker-nexus-iq-rh-build-project-id', variable: 'PROJECT_ID'),
+            string(credentialsId: 'rh-build-service-api-key', variable: 'API_KEY')]) {
+          final redHatVersion = "${version}-ubi"
+          runGroovy('ci/TriggerRedHatBuild.groovy', [redHatVersion, PROJECT_ID, API_KEY].join(' '))
+        }
+      }
+  } finally {
+    OsTools.runSafe(this, 'git clean -f && git reset --hard origin/master')
+  }
+}
+
+def readVersion() {
+  def content = readFile 'Dockerfile'
+  for (line in content.split('\n')) {
+    if (line.startsWith('ARG IQ_SERVER_VERSION=')) {
+      return getShortVersion(line.substring(22))
+    }
+  }
+  error 'Could not determine version.'
+}
+
+def getShortVersion(version) {
+  return version.split('-')[0]
+}

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A Dockerfile for Sonatype Nexus IQ Server, based on [Red Hat Universal Base Imag
 
 
 ### Upgrading from Version 117 or Earlier to Version 118 or Later
-Version 1.117.0 of the Docker image changed the UID of the nexus user from 997 to 1000, and changed it from a system account to a user account. This is to minimize the chance of a future collision with other UIDs. If you use this image with persistent data volumes, then for each volume you will need to run the following command:
+Version 1.118.0 of the Docker image changed the UID of the nexus user from 997 to 1000, and changed it from a system account to a user account. This is to minimize the chance of a future collision with other UIDs. If you use this image with persistent data volumes, then for each volume you will need to run the following command:
 ```
 docker run -it -u=0 -v [volume name]:[volume container path] sonatype/nexus-iq-server:1.117.0 chown -R nexus:nexus [volume container path]
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ e.g.
 ```
 docker run -it -u=0 -v sonatype-work:/sonatype-work sonatype/nexus-iq-server:1.117.0 chown -R nexus:nexus /sonatype-work
 ```
-This will start up a 1.117.0 IQ server container with root as the user, allowing it to chown the sonatype-work directory and its files to the correct nexus user.
+This will start up a 1.118.0 IQ server container with root as the user, allowing it to chown the sonatype-work directory and its files to the correct nexus user.
 
 ### Upgrading from Version 100 or Earlier to Version 101 or Later
 Version 1.101.0 of the Docker image changed the base image from [Red Hat UBI (Universal Base Image)](https://catalog.redhat.com/software/containers/ubi8/ubi/5c359854d70cc534b3a3784e) to a different [Red

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker run -it -u=0 -v [volume name]:[volume container path] sonatype/nexus-iq-s
 ```
 e.g.
 ```
-docker run -it -u=0 -v sonatype-work:/sonatype-work sonatype/nexus-iq-server:1.117.0 chown -R nexus:nexus /sonatype-work
+docker run -it -u=0 -v sonatype-work:/sonatype-work sonatype/nexus-iq-server:1.118.0 chown -R nexus:nexus /sonatype-work
 ```
 This will start up a 1.118.0 IQ server container with root as the user, allowing it to chown the sonatype-work directory and its files to the correct nexus user.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A Dockerfile for Sonatype Nexus IQ Server, based on [Red Hat Universal Base Imag
 ## Migration
 
 
-### Upgrading from Version 116 or Earlier to Version 117 or Later
+### Upgrading from Version 117 or Earlier to Version 118 or Later
 Version 1.117.0 of the Docker image changed the UID of the nexus user from 997 to 1000, and changed it from a system account to a user account. This is to minimize the chance of a future collision with other UIDs. If you use this image with persistent data volumes, then for each volume you will need to run the following command:
 ```
 docker run -it -u=0 -v [volume name]:[volume container path] sonatype/nexus-iq-server:1.117.0 chown -R nexus:nexus [volume container path]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A Dockerfile for Sonatype Nexus IQ Server, based on [Red Hat Universal Base Imag
 ### Upgrading from Version 117 or Earlier to Version 118 or Later
 Version 1.118.0 of the Docker image changed the UID of the nexus user from 997 to 1000, and changed it from a system account to a user account. This is to minimize the chance of a future collision with other UIDs. If you use this image with persistent data volumes, then for each volume you will need to run the following command:
 ```
-docker run -it -u=0 -v [volume name]:[volume container path] sonatype/nexus-iq-server:1.117.0 chown -R nexus:nexus [volume container path]
+docker run -it -u=0 -v [volume name]:[volume container path] sonatype/nexus-iq-server:1.118.0 chown -R nexus:nexus [volume container path]
 ```
 e.g.
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ A Dockerfile for Sonatype Nexus IQ Server, based on [Red Hat Universal Base Imag
 
 ## Migration
 
+
+### Upgrading from Version 116 or Earlier to Version 117 or Later
+Version 1.117.0 of the Docker image changed the UID of the nexus user from 997 to 1000, and changed it from a system account to a user account. This is to minimize the chance of a future collision with other UIDs. If you use this image with persistent data volumes, then for each volume you will need to run the following command:
+```
+docker run -it -u=0 -v [volume name]:[volume container path] sonatype/nexus-iq-server:1.117.0 chown -R nexus:nexus [volume container path]
+```
+e.g.
+```
+docker run -it -u=0 -v sonatype-work:/sonatype-work sonatype/nexus-iq-server:1.117.0 chown -R nexus:nexus /sonatype-work
+```
+This will start up a 1.117.0 IQ server container with root as the user, allowing it to chown the sonatype-work directory and its files to the correct nexus user.
+
 ### Upgrading from Version 100 or Earlier to Version 101 or Later
 Version 1.101.0 of the Docker image changed the base image from [Red Hat UBI (Universal Base Image)](https://catalog.redhat.com/software/containers/ubi8/ubi/5c359854d70cc534b3a3784e) to a different [Red
 Hat UBI that includes OpenJDK 1.8](https://catalog.redhat.com/software/containers/ubi8/openjdk-8/5dd6a48dbed8bd164a09589a). This was due to an effort to remove the dependency on Chef. As a result, the UID of

--- a/ci/TriggerRedHatBuild.groovy
+++ b/ci/TriggerRedHatBuild.groovy
@@ -21,8 +21,8 @@ if (args.size() < 3) {
 new BuildClient(*args).run()
 
 class BuildClient {
-  private static final Integer TIMEOUT_MINUTES = 20
-  private static final Integer POLLING_SECONDS = 60
+  private static final Integer TIMEOUT_MINUTES = 60
+  private static final Integer POLLING_SECONDS = 120
 
   private final String version
   private final String projectId

--- a/spec/Dockerfile_spec.rb
+++ b/spec/Dockerfile_spec.rb
@@ -45,7 +45,7 @@ describe 'Dockerfile' do
     end
 
     it 'has a specific id' do
-      expect(subject).to have_uid(997)
+      expect(subject).to have_uid(1000)
     end
 
     it 'has the installation directory as home directory' do


### PR DESCRIPTION
For the full conversation regarding this you can refer to:

https://sonatype.slack.com/archives/CC2BN7KU6/p1622485542189800

We're trying to mount the drive that contains the lock to remove it (sonatype which is mapped on amazon EFS to be accessed by the IQ container) but we're running into a permission issue. 