### PR TITLE
INT-5222 | Decouple IQ Docker release from RedHat registry certifications

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,6 @@ properties([
     string(defaultValue: '', description: 'New Nexus IQ Version Sha256', name: 'nexus_iq_version_sha'),
 
     booleanParam(defaultValue: false, description: 'Push Docker Image and Tags', name: 'push_image'),
-    booleanParam(defaultValue: false, description: 'Force Red Hat Certified Build for a non-master branch', name: 'force_red_hat_build'),
-    booleanParam(defaultValue: false, description: 'Skip Red Hat Certified Build', name: 'skip_red_hat_build'),
   ])
 ])
 
@@ -182,16 +180,6 @@ node('ubuntu-zion') {
       }
     }
 
-    if ((! params.skip_red_hat_build) && (branch == 'master' || params.force_red_hat_build)) {
-      stage('Trigger Red Hat Certified Image Build') {
-        withCredentials([
-            string(credentialsId: 'docker-nexus-iq-rh-build-project-id', variable: 'PROJECT_ID'),
-            string(credentialsId: 'rh-build-service-api-key', variable: 'API_KEY')]) {
-          final redHatVersion = "${version}-ubi"
-          runGroovy('ci/TriggerRedHatBuild.groovy', [redHatVersion, PROJECT_ID, API_KEY].join(' '))
-        }
-      }
-    }
   } finally {
     OsTools.runSafe(this, "docker logout")
     OsTools.runSafe(this, "docker system prune -a -f")

--- a/Jenkinsfile.rh
+++ b/Jenkinsfile.rh
@@ -4,15 +4,11 @@
  * "Sonatype" is a trademark of Sonatype, Inc.
  */
 @Library(['private-pipeline-library', 'jenkins-shared']) _
-import com.sonatype.jenkins.pipeline.GitHub
 import com.sonatype.jenkins.pipeline.OsTools
 
 node('ubuntu-zion') {
   def version
-  def organization = 'sonatype',
-      gitHubRepository = 'docker-nexus-iq-server',
-      credentialsId = 'integrations-github-api'
-  GitHub gitHub
+  def credentialsId = 'integrations-github-api'
 
   try {
     stage('Preparation') {

--- a/Jenkinsfile.rh
+++ b/Jenkinsfile.rh
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2017-present Sonatype, Inc. All rights reserved.
+ * Includes the third-party code listed at http://links.sonatype.com/products/nexus/attributions.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+@Library(['private-pipeline-library', 'jenkins-shared']) _
+import com.sonatype.jenkins.pipeline.GitHub
+import com.sonatype.jenkins.pipeline.OsTools
+
+node('ubuntu-zion') {
+  def version
+  def organization = 'sonatype',
+      gitHubRepository = 'docker-nexus-iq-server',
+      credentialsId = 'integrations-github-api'
+  GitHub gitHub
+
+  try {
+    stage('Preparation') {
+      deleteDir()
+
+      def checkoutDetails = checkout scm
+
+      checkoutDetails.GIT_BRANCH == 'origin/master' ? 'master' : checkoutDetails.GIT_BRANCH
+
+      version = readVersion()
+    }
+    stage('Trigger Red Hat Certified Image Build') {
+        withCredentials([
+            string(credentialsId: 'docker-nexus-iq-rh-build-project-id', variable: 'PROJECT_ID'),
+            string(credentialsId: 'rh-build-service-api-key', variable: 'API_KEY')]) {
+          final redHatVersion = "${version}-ubi"
+          runGroovy('ci/TriggerRedHatBuild.groovy', [redHatVersion, PROJECT_ID, API_KEY].join(' '))
+        }
+      }
+  } finally {
+    OsTools.runSafe(this, 'git clean -f && git reset --hard origin/master')
+  }
+}
+
+def readVersion() {
+  def content = readFile 'Dockerfile'
+  for (line in content.split('\n')) {
+    if (line.startsWith('ARG IQ_SERVER_VERSION=')) {
+      return getShortVersion(line.substring(22))
+    }
+  }
+  error 'Could not determine version.'
+}
+
+def getShortVersion(version) {
+  return version.split('-')[0]
+}

--- a/ci/TriggerRedHatBuild.groovy
+++ b/ci/TriggerRedHatBuild.groovy
@@ -21,8 +21,8 @@ if (args.size() < 3) {
 new BuildClient(*args).run()
 
 class BuildClient {
-  private static final Integer TIMEOUT_MINUTES = 20
-  private static final Integer POLLING_SECONDS = 60
+  private static final Integer TIMEOUT_MINUTES = 60
+  private static final Integer POLLING_SECONDS = 120
 
   private final String version
   private final String projectId


### PR DESCRIPTION
INT-5222 | Decouple IQ Docker release from RedHat registry certifications

- Removed Red Hat Certified Image Build stage from from the main Jenkinsfile
- Created a new Jenkinsfile.rh file to run Jenkins job [ iq-redhat-certified](https://jenkins.ci.sonatype.dev/job/integrations/job/Red%20Hat%20Certified%20Docker%20Image/job/iq-redhat-certified/ )

Links
Jira: https://issues.sonatype.org/browse/INT-5222
Jenkins: https://jenkins.ci.sonatype.dev/job/integrations/job/Red%20Hat%20Certified%20Docker%20Image/job/iq-redhat-certified/