### PR TITLE
Added Trap for Shutting Down IQ Gracefully

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN cat ${TEMP}/config.yml | sed -r "s/\s*sonatypeWork\s*:\s*\"?[-0-9a-zA-Z_/\\]
 && chmod 0644 ${CONFIG_HOME}/config.yml
 
 # Create start script
-RUN echo "trap 'kill -TERM \`cut -f1 -d@ $SONATYPE_WORK/lock\`  && sleep 60' SIGTERM" > ${IQ_HOME}/start.sh \
+RUN echo "trap 'kill -TERM \`cut -f1 -d@ ${SONATYPE_WORK}/lock\` && sleep 60' SIGTERM" > ${IQ_HOME}/start.sh \
 && echo "/usr/bin/java \${JAVA_OPTS} -jar nexus-iq-server-${IQ_SERVER_VERSION}.jar server ${CONFIG_HOME}/config.yml 2> ${LOGS_HOME}/stderr.log & " >> ${IQ_HOME}/start.sh \
 && echo "wait" >> ${IQ_HOME}/start.sh \
 && chmod 0755 ${IQ_HOME}/start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,9 @@ RUN cat ${TEMP}/config.yml | sed -r "s/\s*sonatypeWork\s*:\s*\"?[-0-9a-zA-Z_/\\]
 && chmod 0644 ${CONFIG_HOME}/config.yml
 
 # Create start script
-RUN echo "/usr/bin/java \${JAVA_OPTS} -jar nexus-iq-server-${IQ_SERVER_VERSION}.jar server ${CONFIG_HOME}/config.yml 2> ${LOGS_HOME}/stderr.log" > ${IQ_HOME}/start.sh \
+RUN echo "trap 'kill -TERM \`cut -f1 -d@ $SONATYPE_WORK/lock\`  && sleep 60' SIGTERM" > ${IQ_HOME}/start.sh \
+&& echo "/usr/bin/java \${JAVA_OPTS} -jar nexus-iq-server-${IQ_SERVER_VERSION}.jar server ${CONFIG_HOME}/config.yml 2> ${LOGS_HOME}/stderr.log & " >> ${IQ_HOME}/start.sh \
+&& echo "wait" >> ${IQ_HOME}/start.sh \
 && chmod 0755 ${IQ_HOME}/start.sh
 
 # Download the server bundle, verify its checksum, and extract the server jar to the install directory

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -64,8 +64,11 @@ RUN cat ${TEMP}/config.yml | sed -r "s/\s*sonatypeWork\s*:\s*\"?[-0-9a-zA-Z_/\\]
 && chmod 0644 ${CONFIG_HOME}/config.yml
 
 # Create start script
-RUN echo "/usr/bin/java \${JAVA_OPTS} -jar nexus-iq-server-${IQ_SERVER_VERSION}.jar server ${CONFIG_HOME}/config.yml 2> ${LOGS_HOME}/stderr.log" > ${IQ_HOME}/start.sh \
+RUN echo "trap 'kill -TERM \`cut -f1 -d@ $SONATYPE_WORK/lock\`  && sleep 60' SIGTERM" > ${IQ_HOME}/start.sh \
+&& echo "/usr/bin/java \${JAVA_OPTS} -jar nexus-iq-server-${IQ_SERVER_VERSION}.jar server ${CONFIG_HOME}/config.yml 2> ${LOGS_HOME}/stderr.log & " >> ${IQ_HOME}/start.sh \
+&& echo "wait" >> ${IQ_HOME}/start.sh \
 && chmod 0755 ${IQ_HOME}/start.sh
+
 
 # Download the server bundle, verify its checksum, and extract the server jar to the install directory
 RUN cd ${TEMP} \


### PR DESCRIPTION
Updated startup.sh to trap sigterm for graceful shutdown of IQ

Jira: https://issues.sonatype.org/browse/CLM-18614
Jenkins: https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/docker-nexus-iq-server-feature/job/CLM-18614-stop-gracefully/lastBuild/ 