### PR TITLE
Clm 18632 fix iq snapshot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG SONATYPE_WORK="/sonatype-work"
 ARG CONFIG_HOME="/etc/nexus-iq-server"
 ARG LOGS_HOME="/var/log/nexus-iq-server"
 ARG GID=1000
-ARG UID=997
+ARG UID=1000
 
 LABEL name="Nexus IQ Server image" \
   maintainer="Sonatype <support@sonatype.com>" \
@@ -79,7 +79,7 @@ RUN cd ${TEMP} \
 \
 # Add group and user
 && groupadd -g ${GID} nexus \
-&& adduser -u ${UID} -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false -r nexus \
+&& adduser -u ${UID} -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false nexus \
 \
 # Change owner to nexus user
 && chown -R nexus:nexus ${IQ_HOME} \

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -23,7 +23,7 @@ ARG SONATYPE_WORK="/sonatype-work"
 ARG CONFIG_HOME="/etc/nexus-iq-server"
 ARG LOGS_HOME="/var/log/nexus-iq-server"
 ARG GID=1000
-ARG UID=997
+ARG UID=1000
 
 LABEL name="Nexus IQ Server image" \
   maintainer="Sonatype <support@sonatype.com>" \
@@ -79,7 +79,7 @@ RUN cd ${TEMP} \
 \
 # Add group and user
 && groupadd -g ${GID} nexus \
-&& adduser -u ${UID} -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false -r nexus \
+&& adduser -u ${UID} -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false nexus \
 \
 # Change owner to nexus user
 && chown -R nexus:nexus ${IQ_HOME} \

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A Dockerfile for Sonatype Nexus IQ Server, based on [Red Hat Universal Base Imag
 
 
 ### Upgrading from Version 117 or Earlier to Version 118 or Later
-Version 1.117.0 of the Docker image changed the UID of the nexus user from 997 to 1000, and changed it from a system account to a user account. This is to minimize the chance of a future collision with other UIDs. If you use this image with persistent data volumes, then for each volume you will need to run the following command:
+Version 1.118.0 of the Docker image changed the UID of the nexus user from 997 to 1000, and changed it from a system account to a user account. This is to minimize the chance of a future collision with other UIDs. If you use this image with persistent data volumes, then for each volume you will need to run the following command:
 ```
 docker run -it -u=0 -v [volume name]:[volume container path] sonatype/nexus-iq-server:1.117.0 chown -R nexus:nexus [volume container path]
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ e.g.
 ```
 docker run -it -u=0 -v sonatype-work:/sonatype-work sonatype/nexus-iq-server:1.117.0 chown -R nexus:nexus /sonatype-work
 ```
-This will start up a 1.117.0 IQ server container with root as the user, allowing it to chown the sonatype-work directory and its files to the correct nexus user.
+This will start up a 1.118.0 IQ server container with root as the user, allowing it to chown the sonatype-work directory and its files to the correct nexus user.
 
 ### Upgrading from Version 100 or Earlier to Version 101 or Later
 Version 1.101.0 of the Docker image changed the base image from [Red Hat UBI (Universal Base Image)](https://catalog.redhat.com/software/containers/ubi8/ubi/5c359854d70cc534b3a3784e) to a different [Red

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker run -it -u=0 -v [volume name]:[volume container path] sonatype/nexus-iq-s
 ```
 e.g.
 ```
-docker run -it -u=0 -v sonatype-work:/sonatype-work sonatype/nexus-iq-server:1.117.0 chown -R nexus:nexus /sonatype-work
+docker run -it -u=0 -v sonatype-work:/sonatype-work sonatype/nexus-iq-server:1.118.0 chown -R nexus:nexus /sonatype-work
 ```
 This will start up a 1.118.0 IQ server container with root as the user, allowing it to chown the sonatype-work directory and its files to the correct nexus user.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A Dockerfile for Sonatype Nexus IQ Server, based on [Red Hat Universal Base Imag
 ## Migration
 
 
-### Upgrading from Version 116 or Earlier to Version 117 or Later
+### Upgrading from Version 117 or Earlier to Version 118 or Later
 Version 1.117.0 of the Docker image changed the UID of the nexus user from 997 to 1000, and changed it from a system account to a user account. This is to minimize the chance of a future collision with other UIDs. If you use this image with persistent data volumes, then for each volume you will need to run the following command:
 ```
 docker run -it -u=0 -v [volume name]:[volume container path] sonatype/nexus-iq-server:1.117.0 chown -R nexus:nexus [volume container path]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A Dockerfile for Sonatype Nexus IQ Server, based on [Red Hat Universal Base Imag
 ### Upgrading from Version 117 or Earlier to Version 118 or Later
 Version 1.118.0 of the Docker image changed the UID of the nexus user from 997 to 1000, and changed it from a system account to a user account. This is to minimize the chance of a future collision with other UIDs. If you use this image with persistent data volumes, then for each volume you will need to run the following command:
 ```
-docker run -it -u=0 -v [volume name]:[volume container path] sonatype/nexus-iq-server:1.117.0 chown -R nexus:nexus [volume container path]
+docker run -it -u=0 -v [volume name]:[volume container path] sonatype/nexus-iq-server:1.118.0 chown -R nexus:nexus [volume container path]
 ```
 e.g.
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ A Dockerfile for Sonatype Nexus IQ Server, based on [Red Hat Universal Base Imag
 
 ## Migration
 
+
+### Upgrading from Version 116 or Earlier to Version 117 or Later
+Version 1.117.0 of the Docker image changed the UID of the nexus user from 997 to 1000, and changed it from a system account to a user account. This is to minimize the chance of a future collision with other UIDs. If you use this image with persistent data volumes, then for each volume you will need to run the following command:
+```
+docker run -it -u=0 -v [volume name]:[volume container path] sonatype/nexus-iq-server:1.117.0 chown -R nexus:nexus [volume container path]
+```
+e.g.
+```
+docker run -it -u=0 -v sonatype-work:/sonatype-work sonatype/nexus-iq-server:1.117.0 chown -R nexus:nexus /sonatype-work
+```
+This will start up a 1.117.0 IQ server container with root as the user, allowing it to chown the sonatype-work directory and its files to the correct nexus user.
+
 ### Upgrading from Version 100 or Earlier to Version 101 or Later
 Version 1.101.0 of the Docker image changed the base image from [Red Hat UBI (Universal Base Image)](https://catalog.redhat.com/software/containers/ubi8/ubi/5c359854d70cc534b3a3784e) to a different [Red
 Hat UBI that includes OpenJDK 1.8](https://catalog.redhat.com/software/containers/ubi8/openjdk-8/5dd6a48dbed8bd164a09589a). This was due to an effort to remove the dependency on Chef. As a result, the UID of

--- a/spec/Dockerfile_spec.rb
+++ b/spec/Dockerfile_spec.rb
@@ -45,7 +45,7 @@ describe 'Dockerfile' do
     end
 
     it 'has a specific id' do
-      expect(subject).to have_uid(997)
+      expect(subject).to have_uid(1000)
     end
 
     it 'has the installation directory as home directory' do


### PR DESCRIPTION
For the full conversation regarding this you can refer to:

https://sonatype.slack.com/archives/CC2BN7KU6/p1622485542189800

We're trying to mount the drive that contains the lock to remove it (sonatype which is mapped on amazon EFS to be accessed by the IQ container) but we're running into a permission issue.


 **This is to clean up some of the discrepancies shown here: https://github.com/sonatype/docker-nexus-iq-server/pull/68. There is no new changes here compared to https://github.com/sonatype/docker-nexus-iq-server/pull/68. this is just to show the net difference between master and this branch**
 

