### PR TITLE
INT-5317 | Chain RedHat job to Docker Insight job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -178,6 +178,9 @@ node('ubuntu-zion') {
         }
         OsTools.runSafe(this, "git tag -d ${version}")
       }
+
+      //Trigger the Red Hat job and It does not care about this result
+      build(job: '/integrations/Red Hat Certified Docker Image/iq-redhat-certified', wait: false)
     }
 
   } finally {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -180,7 +180,9 @@ node('ubuntu-zion') {
       }
 
       //Trigger the Red Hat job and It does not care about this result
-      build(job: '/integrations/Red Hat Certified Docker Image/iq-redhat-certified', wait: false)
+      stage('Trigger Red Hat Certified Job Build') {
+        build(job: '/integrations/Red Hat Certified Docker Image/iq-redhat-certified', wait: false)
+      }
     }
 
   } finally {


### PR DESCRIPTION
Chain the current IQ Docker build to new RedHat publishing job so that it is kicked off automatically



**Links**
JIRA: https://issues.sonatype.org/browse/INT-5317 
Jenkins: https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/docker-nexus-iq-server-feature/job/INT-5317-chain-redhat-job-insight-job/2/console