### PR TITLE
BNR-137 Remove obsolete parameter "push_image"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,8 +11,6 @@ properties([
   parameters([
     string(defaultValue: '', description: 'New Nexus IQ Version', name: 'nexus_iq_version'),
     string(defaultValue: '', description: 'New Nexus IQ Version Sha256', name: 'nexus_iq_version_sha'),
-
-    booleanParam(defaultValue: false, description: 'Push Docker Image and Tags', name: 'push_image'),
   ])
 ])
 
@@ -101,7 +99,7 @@ node('ubuntu-zion') {
         OsTools.runSafe(this, "docker save ${imageName} -o ${tarName}")
       
         //decide which stage we are creating
-        def theStage = branch == 'master' ? (params.push_image ? 'release' : 'stage-release') : 'build'
+        def theStage = branch == 'master' ? 'release' : 'build'
 
         //run the evaluation
         nexusPolicyEvaluation iqStage: theStage, iqApplication: iqApplicationId,
@@ -135,7 +133,7 @@ node('ubuntu-zion') {
       }
     }
 
-    if (branch == 'master' && params.push_image) {
+    if (branch == 'master') {
       stage('Push image') {
         def dockerHubApiToken
         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'docker-hub-credentials',


### PR DESCRIPTION
Jira: https://issues.sonatype.org/browse/BNR-137 

The instructions in [CLM-18731](https://issues.sonatype.org/browse/CLM-18731)  explain, the "push_image" param is used to  enable pushing the image to Docker Hub. 

My assumption is the only time we don't want to push the image to Docker Hub is when the main part of the build passes, but the triggering RH part failed e.g. we wanted to retry publishing to RH, but leaving the Docker Hub image alone.

Now that publishing to RH container registry has been separated, I think it make sense to drop the "push_image" param.