### PR TITLE
BNR-141 Compute IQ Version and Sha for docker-nexus-iq-server build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,8 +22,8 @@ node('ubuntu-zion') {
   try {
     stage('Init IQ Version & Sha') {
       nexusIqVersion = getVersionFromBuildName(env.releaseBuild_NAME)
-      gatherBuildArtifacts('insight/insight-brain/release', env.releaseBuild_NUMBER)
-      nexusIqSha = readFile(file: "artifacts/nexus-iq-server-${nexusIqVersion}-bundle.tar.gz.sha256", encoding: 'UTF-8')
+      nexusIqSha = readBuildArtifact('insight/insight-brain/release', env.releaseBuild_NUMBER,
+        "artifacts/nexus-iq-server-${nexusIqVersion}-bundle.tar.gz.sha256")
     }
     stage('Preparation') {
       deleteDir()


### PR DESCRIPTION
Jira: https://issues.sonatype.org/browse/BNR-141 
Jenkins Build: https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/docker-nexus-iq-server/ 

**Description**
Currently the user performing the release has to manually enter the iq version and sha256 (after downloading the iq bundle and using a tool to calculate).

**Current**
![image](https://user-images.githubusercontent.com/38332365/123519592-36f5ef80-d6a4-11eb-8cc9-c4aa3bf1d520.png)
The user has to manually enter iq version and sha256 (after downloading iq bundle and using an os tool to calculate)

**Proposed Change**
![image](https://user-images.githubusercontent.com/38332365/123430794-7fd47800-d5c0-11eb-8a6f-151218f7253d.png)
User selects the latest iq release from drop down. The version and sha are automatically extracted.