### PR TITLE
INT-5698 upgrade and adjust for openjdk-8:1.10 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,17 +82,14 @@ RUN cd ${TEMP} \
 && cd ${IQ_HOME} \
 && rm -rf ${TEMP} \
 \
-# Add group and user
+# Add group and user and copy passwd to the nss_wrapper location
 && groupadd -g ${GID} nexus \
 && adduser -u ${UID} -M -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false nexus \
 && cp /etc/passwd /home/jboss/passwd \
+&& chmod 755 /home/jboss \
 \
 # Change owner to nexus user
-&& chown -R nexus:nexus ${IQ_HOME} \
-&& chown -R nexus:nexus ${SONATYPE_WORK} \
-&& chown -R nexus:nexus ${CONFIG_HOME} \
-&& chown -R nexus:nexus ${LOGS_HOME} \
-&& chmod 755 /home/jboss
+&& chown -R nexus:nexus ${IQ_HOME} ${SONATYPE_WORK} ${CONFIG_HOME} ${LOGS_HOME}
 
 # This is where we will store persistent data
 VOLUME ${SONATYPE_WORK}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/openjdk-8:1.3-8
+FROM registry.access.redhat.com/ubi8/openjdk-8:1.10-1
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.124.0-01
 ARG IQ_SERVER_SHA256=d98352382be6552edab9e3631fc7fbda3813b97fc7c0e867f39d71bd5c902a70
-
-
-
-
 
 ARG TEMP="/tmp/work"
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
@@ -54,8 +50,9 @@ LABEL name="Nexus IQ Server image" \
 USER root
 
 # For testing
-RUN dnf update --allowerasing -y \
-&& dnf install -y procps
+RUN microdnf update -y \
+&& microdnf install -y procps gzip \
+&& microdnf clean all
 
 # Create folders
 RUN mkdir -p ${TEMP} \
@@ -87,13 +84,15 @@ RUN cd ${TEMP} \
 \
 # Add group and user
 && groupadd -g ${GID} nexus \
-&& adduser -u ${UID} -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false nexus \
+&& adduser -u ${UID} -M -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false nexus \
+&& cp /etc/passwd /home/jboss/passwd \
 \
 # Change owner to nexus user
 && chown -R nexus:nexus ${IQ_HOME} \
 && chown -R nexus:nexus ${SONATYPE_WORK} \
 && chown -R nexus:nexus ${CONFIG_HOME} \
-&& chown -R nexus:nexus ${LOGS_HOME}
+&& chown -R nexus:nexus ${LOGS_HOME} \
+&& chmod 755 /home/jboss
 
 # This is where we will store persistent data
 VOLUME ${SONATYPE_WORK}

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -12,15 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/openjdk-8:1.3-8
+FROM registry.access.redhat.com/ubi8/openjdk-8:1.10-1
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.124.0-01
 ARG IQ_SERVER_SHA256=d98352382be6552edab9e3631fc7fbda3813b97fc7c0e867f39d71bd5c902a70
-
-
-
-
 
 ARG TEMP="/tmp/work"
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
@@ -54,8 +50,9 @@ LABEL name="Nexus IQ Server image" \
 USER root
 
 # For testing
-RUN dnf update --allowerasing -y \
-&& dnf install -y procps
+RUN microdnf update -y \
+&& microdnf install -y procps gzip \
+&& microdnf clean all
 
 # Create folders
 RUN mkdir -p ${TEMP} \
@@ -89,20 +86,17 @@ RUN cd ${TEMP} \
 # Add group and user
 && groupadd -g ${GID} nexus \
 && adduser -u ${UID} -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false nexus \
+&& cp /etc/passwd /home/jboss/passwd \
+&& chmod 755 /home/jboss \
 \
 # Change owner to nexus user
-&& chown -R nexus:nexus ${IQ_HOME} \
-&& chown -R nexus:nexus ${SONATYPE_WORK} \
-&& chown -R nexus:nexus ${CONFIG_HOME} \
-&& chown -R nexus:nexus ${LOGS_HOME}
+&& chown -R nexus:nexus ${IQ_HOME} ${SONATYPE_WORK} ${CONFIG_HOME} ${LOGS_HOME}
 
 # Red Hat Certified Container commands
 COPY rh-docker /
 RUN usermod -a -G root nexus \
 && chmod -R 0755 /licenses \
-&& chmod 0755 /help.1 \
-&& chmod 0755 /uid_entrypoint.sh \
-&& chmod 0755 /uid_template.sh \
+&& chmod 0755 /help.1 /uid_entrypoint.sh /uid_template.sh \
 && bash /uid_template.sh \
 && chmod 0664 /etc/passwd
 

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -83,7 +83,7 @@ RUN cd ${TEMP} \
 && cd ${IQ_HOME} \
 && rm -rf ${TEMP} \
 \
-# Add group and user
+# Add group and user and copy passwd to the nss_wrapper location
 && groupadd -g ${GID} nexus \
 && adduser -u ${UID} -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false nexus \
 && cp /etc/passwd /home/jboss/passwd \


### PR DESCRIPTION
We can't get rid of all the security issues found by artifacthub (with trivy), but upgrading to the base image can chip away at it.

JIRA: https://issues.sonatype.org/browse/INT-5698