### PR TITLE
INT-5698 build off ubi-minimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ USER root
 # For testing
 RUN microdnf update -y \
 && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-devel \
-&& microdnf install -y procps gzip tar shadow-utils \
+&& microdnf install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync \
 && microdnf clean all
 
 # Create folders

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/openjdk-8:1.3-8
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-210
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.124.0-01
 ARG IQ_SERVER_SHA256=d98352382be6552edab9e3631fc7fbda3813b97fc7c0e867f39d71bd5c902a70
-
-
-
-
 
 ARG TEMP="/tmp/work"
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
@@ -54,8 +50,10 @@ LABEL name="Nexus IQ Server image" \
 USER root
 
 # For testing
-RUN dnf update --allowerasing -y \
-&& dnf install -y procps
+RUN microdnf update -y \
+&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-devel \
+&& microdnf install -y procps gzip tar shadow-utils \
+&& microdnf clean all
 
 # Create folders
 RUN mkdir -p ${TEMP} \

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -53,7 +53,7 @@ USER root
 # For testing
 RUN microdnf update -y \
 && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-devel \
-&& microdnf install -y procps gzip tar shadow-utils \
+&& microdnf install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync \
 && microdnf clean all
 
 # Create folders

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -12,15 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/openjdk-8:1.3-8
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-210
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.124.0-01
 ARG IQ_SERVER_SHA256=d98352382be6552edab9e3631fc7fbda3813b97fc7c0e867f39d71bd5c902a70
-
-
-
-
 
 ARG TEMP="/tmp/work"
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
@@ -54,8 +50,11 @@ LABEL name="Nexus IQ Server image" \
 USER root
 
 # For testing
-RUN dnf update --allowerasing -y \
-&& dnf install -y procps
+# For testing
+RUN microdnf update -y \
+&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-devel \
+&& microdnf install -y procps gzip tar shadow-utils \
+&& microdnf clean all
 
 # Create folders
 RUN mkdir -p ${TEMP} \


### PR DESCRIPTION
instead of openjdk-8.

* microdnf install openjdk for ourselves
* eliminate lots of extra source-to-image infrastructure and nss_wrapper, etc
  that we don't want
* less work-arounds and mystery than provided with latest openjdk-8 image

JIRA: https://issues.sonatype.org/browse/INT-5698

Alternative to https://github.com/sonatype/docker-nexus-iq-server/pull/80.