### PR TITLE
update to latest ubi version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-212
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-204
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.126.0-01

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-210
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-212
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.126.0-01

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-212
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-204
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.126.0-01

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-210
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-212
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.126.0-01


### PR DESCRIPTION
As per https://docs.sonatype.com/display/ENG/Lifecycle+Policy+Violation+Handling+Process, when Neuvector finds violations, we update to the latest base image before releasing. 

