### PR TITLE
remove trigger of red hat builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,13 +175,7 @@ node('ubuntu-zion') {
         }
         OsTools.runSafe(this, "git tag -d ${version}")
       }
-
-      //Trigger the Red Hat job and It does not care about this result
-      stage('Trigger Red Hat Certified Job Build') {
-        build(job: '/integrations/Red Hat Certified Docker Image/iq-redhat-certified', wait: false)
-      }
     }
-
   } finally {
     OsTools.runSafe(this, "docker logout")
     OsTools.runSafe(this, "docker system prune -a -f")


### PR DESCRIPTION
The plain docker build doesn't need to trigger the broken Red Hat build right now, since the deployment process instead creates a follow-up deployment task in JIRA for the integrations team.

Build: https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/docker-nexus-iq-server-feature/job/do-not-trigger-red-hat-build/