### PR TITLE
Do not save docker image for policy evaluations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,16 +93,12 @@ node('ubuntu-zion') {
       }
     }
     stage('Evaluate') {
-      dir('build') {
-        writeFile file:'dummy', text:'why-do-we-need-this-folder'
+      //decide which stage we are creating
+      def theStage = branch == 'master' ? 'release' : 'build'
 
-        //decide which stage we are creating
-        def theStage = branch == 'master' ? 'release' : 'build'
-
-        runEvaluation({ stage ->
-          nexusPolicyEvaluation(iqStage: stage, iqApplication: iqApplicationId,
-          iqScanPatterns: [[scanPattern: "container:${imageName}"]], failBuildOnNetworkError: true)}, theStage)
-      }
+      runEvaluation({ stage ->
+        nexusPolicyEvaluation(iqStage: stage, iqApplication: iqApplicationId,
+        iqScanPatterns: [[scanPattern: "container:${imageName}"]], failBuildOnNetworkError: true)}, theStage)
     }
 
     if (currentBuild.result == 'FAILURE') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,9 +93,9 @@ node('ubuntu-zion') {
       }
     }
     stage('Evaluate') {
-      
-      //Create tar of our image
       dir('build') {
+        writeFile file:'dummy', text:'why-do-we-need-this-folder'
+
         //decide which stage we are creating
         def theStage = branch == 'master' ? 'release' : 'build'
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,8 +96,6 @@ node('ubuntu-zion') {
       
       //Create tar of our image
       dir('build') {
-        OsTools.runSafe(this, "docker save ${imageName}")
-
         //decide which stage we are creating
         def theStage = branch == 'master' ? 'release' : 'build'
 


### PR DESCRIPTION
We do not need to save the docker image for policy evaluations anymore. We used to save a `tar` file which we scanned, but now we are directly scanning the image itself using Nexus Container. 

https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/docker-nexus-iq-server-feature/job/Do-Not-Save-Docker-Image/