### PR TITLE
INT-6593 Adjusting user agent for IQ server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,6 +117,7 @@ HEALTHCHECK CMD curl --fail --silent --show-error http://localhost:8071/healthch
 USER nexus
 
 ENV JAVA_OPTS="-Djava.util.prefs.userRoot=${SONATYPE_WORK}/javaprefs"
+ENV SONATYPE_INTERNAL_HOST_SYSTEM=Docker
 
 WORKDIR ${IQ_HOME}
 

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -129,6 +129,7 @@ HEALTHCHECK CMD curl --fail --silent --show-error http://localhost:8071/healthch
 USER nexus
 
 ENV JAVA_OPTS="-Djava.util.prefs.userRoot=${SONATYPE_WORK}/javaprefs"
+ENV SONATYPE_INTERNAL_HOST_SYSTEM=Docker-RedHat
 
 WORKDIR ${IQ_HOME}
 

--- a/spec/Dockerfile_spec.rb
+++ b/spec/Dockerfile_spec.rb
@@ -146,6 +146,10 @@ describe 'Dockerfile' do
       it 'contains JAVA_OPTS' do
         expect(startScript.content).to include('${JAVA_OPTS}')
       end
+
+      it 'contains SONATYPE_INTERNAL_HOST_SYSTEM' do
+        expect(startScript.content).to include('${SONATYPE_INTERNAL_HOST_SYSTEM}')
+      end
     end
   end
 

--- a/spec/Dockerfile_spec.rb
+++ b/spec/Dockerfile_spec.rb
@@ -146,10 +146,6 @@ describe 'Dockerfile' do
       it 'contains JAVA_OPTS' do
         expect(startScript.content).to include('${JAVA_OPTS}')
       end
-
-      it 'contains SONATYPE_INTERNAL_HOST_SYSTEM' do
-        expect(startScript.content).to include('${SONATYPE_INTERNAL_HOST_SYSTEM}')
-      end
     end
   end
 


### PR DESCRIPTION
Adjusting user agent for IQ server on docker image and RedHat docker image. Now the user agents will look like this:
* For IQ Server Docker Image
```bash
Sonatype_CLM_Server/1.132.0-01 (Java 1.8.0_40; Mac OS X 10.11.5; Docker)
```
* For IQ Server RedHat Docker Image
```bash
Sonatype_CLM_Server/1.132.0-01 (Java 1.8.0_40; Mac OS X 10.11.5; Docker-RedHat)
```

Here is a dashboard with the metrics coming to DataDog:
* https://app.datadoghq.com/dashboard/9g8-6vc-4pr/iq-server-versions-in-use-hectors-test?from_ts=1646404129647&to_ts=1646407729647&live=true

JIRA: https://issues.sonatype.org/browse/INT-6593
Build: https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/docker-nexus-iq-server-feature/job/INT-6593-update-server-user-agent/