### PR TITLE
INT-6646 add git binary for scm features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,16 +18,6 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-204
 ARG IQ_SERVER_VERSION=1.134.0-02
 ARG IQ_SERVER_SHA256=86940e1cf0bd9fe9865352a6a921f3db788006d2fa7ff2968db54bc8cc0ac1b2
 
-
-
-
-
-
-
-
-
-
-
 ARG TEMP="/tmp/work"
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
 ARG SONATYPE_WORK="/sonatype-work"
@@ -62,7 +52,7 @@ USER root
 # For testing
 RUN microdnf update -y \
 && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-devel \
-&& microdnf install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync \
+&& microdnf install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git \
 && microdnf clean all
 
 # Create folders

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -18,16 +18,6 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-204
 ARG IQ_SERVER_VERSION=1.134.0-02
 ARG IQ_SERVER_SHA256=86940e1cf0bd9fe9865352a6a921f3db788006d2fa7ff2968db54bc8cc0ac1b2
 
-
-
-
-
-
-
-
-
-
-
 ARG TEMP="/tmp/work"
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
 ARG SONATYPE_WORK="/sonatype-work"
@@ -63,7 +53,7 @@ USER root
 # For testing
 RUN microdnf update -y \
 && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-devel \
-&& microdnf install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync \
+&& microdnf install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git \
 && microdnf clean all
 
 # Create folders


### PR DESCRIPTION
we can use native git for more efficient scm features:
* sparse checkout
* shallow clone

JIRA: https://issues.sonatype.org/browse/INT-6646
Build: https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/docker-nexus-iq-server-feature/job/INT-6646-add-git-binary-for-scm/