### PR TITLE
INT-6717 alternative slim image

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,0 +1,116 @@
+# Copyright (c) 2017-present Sonatype, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-204
+
+# Build parameters
+ARG IQ_SERVER_VERSION=1.135.0-01
+ARG IQ_SERVER_SHA256=5005ba518380ae3dc70f09de5cc43b9e70e7eff979d1fb9ad07ff35985febfdf
+
+
+ARG TEMP="/tmp/work"
+ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
+ARG SONATYPE_WORK="/sonatype-work"
+ARG CONFIG_HOME="/etc/nexus-iq-server"
+ARG LOGS_HOME="/var/log/nexus-iq-server"
+ARG GID=1000
+ARG UID=1000
+ARG TIMEOUT=600
+
+LABEL name="Nexus IQ Server image" \
+  maintainer="Sonatype <support@sonatype.com>" \
+  vendor=Sonatype \
+  version="${IQ_SERVER_VERSION}" \
+  release="1.135.0" \
+  url="https://www.sonatype.com" \
+  summary="The Nexus IQ Server" \
+  description="Nexus IQ Server is a policy engine powered by precise intelligence on open source components. \
+    It provides a number of tools to improve component usage in your software supply chain, allowing you to \
+    automate your processes and achieve accelerated speed to delivery while also increasing product quality" \
+  com.sonatype.license="Apache License, Version 2.0" \
+  com.sonatype.name="Nexus IQ Server image" \
+  run="docker run -d -p 8070:8070 -p 8071:8071 IMAGE" \
+  io.k8s.description="Nexus IQ Server is a policy engine powered by precise intelligence on open source components. \
+    It provides a number of tools to improve component usage in your software supply chain, allowing you to \
+    automate your processes and achieve accelerated speed to delivery while also increasing product quality" \
+  io.k8s.display-name="Nexus IQ Server" \
+  io.openshift.expose-services="8071:8071" \
+  io.openshift.tags="Sonatype,Nexus,IQ Server"
+
+USER root
+
+# For testing
+RUN microdnf update -y \
+&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-devel \
+&& microdnf install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync \
+&& microdnf clean all
+
+# Create folders
+RUN mkdir -p ${TEMP} \
+&& mkdir -m 0755 -p ${IQ_HOME} \
+&& mkdir -m 0755 -p ${SONATYPE_WORK} \
+&& mkdir -m 0755 -p ${CONFIG_HOME} \
+&& mkdir -m 0755 -p ${LOGS_HOME}
+
+# Copy config.yml and set sonatypeWork to the correct value
+COPY config.yml ${TEMP}
+RUN cat ${TEMP}/config.yml | sed -r "s/\s*sonatypeWork\s*:\s*\"?[-0-9a-zA-Z_/\\]+\"?/sonatypeWork: ${SONATYPE_WORK//\//\\/}/" > ${CONFIG_HOME}/config.yml \
+&& chmod 0644 ${CONFIG_HOME}/config.yml
+
+# Create start script
+RUN echo "trap 'kill -TERM \`cut -f1 -d@ ${SONATYPE_WORK}/lock\`; timeout ${TIMEOUT} tail --pid=\`cut -f1 -d@ ${SONATYPE_WORK}/lock\` -f /dev/null' SIGTERM" > ${IQ_HOME}/start.sh \
+&& echo "/usr/bin/java \${JAVA_OPTS} -jar nexus-iq-server-${IQ_SERVER_VERSION}.jar server ${CONFIG_HOME}/config.yml 2> ${LOGS_HOME}/stderr.log & " >> ${IQ_HOME}/start.sh \
+&& echo "wait" >> ${IQ_HOME}/start.sh \
+&& chmod 0755 ${IQ_HOME}/start.sh
+
+# Download the server bundle, verify its checksum, and extract the server jar to the install directory
+RUN cd ${TEMP} \
+&& curl -L https://download.sonatype.com/clm/server/nexus-iq-server-${IQ_SERVER_VERSION}-bundle.tar.gz --output nexus-iq-server-${IQ_SERVER_VERSION}-bundle.tar.gz \
+&& echo "${IQ_SERVER_SHA256} nexus-iq-server-${IQ_SERVER_VERSION}-bundle.tar.gz" > nexus-iq-server-${IQ_SERVER_VERSION}-bundle.tar.gz.sha256 \
+&& sha256sum -c nexus-iq-server-${IQ_SERVER_VERSION}-bundle.tar.gz.sha256 \
+&& tar -xvf nexus-iq-server-${IQ_SERVER_VERSION}-bundle.tar.gz \
+&& mv nexus-iq-server-${IQ_SERVER_VERSION}.jar ${IQ_HOME} \
+&& cd ${IQ_HOME} \
+&& rm -rf ${TEMP} \
+\
+# Add group and user
+&& groupadd -g ${GID} nexus \
+&& adduser -u ${UID} -d ${IQ_HOME} -c "Nexus IQ user" -g nexus -s /bin/false nexus \
+\
+# Change owner to nexus user
+&& chown -R nexus:nexus ${IQ_HOME} \
+&& chown -R nexus:nexus ${SONATYPE_WORK} \
+&& chown -R nexus:nexus ${CONFIG_HOME} \
+&& chown -R nexus:nexus ${LOGS_HOME}
+
+# This is where we will store persistent data
+VOLUME ${SONATYPE_WORK}
+VOLUME ${LOGS_HOME}
+
+# Expose the ports
+EXPOSE 8070
+EXPOSE 8071
+
+# Wire up health check
+HEALTHCHECK CMD curl --fail --silent --show-error http://localhost:8071/healthcheck || exit 1
+
+# Change to nexus user
+USER nexus
+
+ENV JAVA_OPTS="-Djava.util.prefs.userRoot=${SONATYPE_WORK}/javaprefs"
+ENV SONATYPE_INTERNAL_HOST_SYSTEM=Docker
+
+WORKDIR ${IQ_HOME}
+
+CMD [ "sh", "./start.sh" ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,8 +34,9 @@ node('ubuntu-zion') {
       def checkoutDetails = checkout scm
 
       dockerFileLocations = [
-          "${pwd()}/Dockerfile",
-          "${pwd()}/Dockerfile.rh"
+        "${pwd()}/Dockerfile",
+        "${pwd()}/Dockerfile.slim",
+        "${pwd()}/Dockerfile.rh",
       ]
 
       branch = checkoutDetails.GIT_BRANCH == 'origin/master' ? 'master' : checkoutDetails.GIT_BRANCH
@@ -64,7 +65,7 @@ node('ubuntu-zion') {
     stage('Build') {
       gitHub.statusUpdate commitId, 'pending', 'build', 'Build is running'
 
-      def hash = OsTools.runSafe(this, "docker build --quiet --no-cache --tag ${imageName} .")
+      def hash = OsTools.runSafe(this, "docker build --quiet --no-cache -f Dockerfile --tag ${imageName} .")
       imageId = hash.split(':')[1]
 
       if (currentBuild.result == 'FAILURE') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -202,7 +202,7 @@ def readVersion() {
   error 'Could not determine version.'
 }
 
-def buildImage(dockerFile, imageName) {
+String buildImage(String dockerFile, String imageName) {
   OsTools.runSafe(this, "docker build --quiet --no-cache -f ${dockerFile} --tag ${imageName} .")
     .split(':')[1]
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,6 +133,9 @@ node('ubuntu-zion') {
       dir('build/target') {
         OsTools.runSafe(this, "docker save ${imageName} | gzip > ${archiveName}.tar.gz")
         archiveArtifacts artifacts: "${archiveName}.tar.gz", onlyIfSuccessful: true
+
+        OsTools.runSafe(this, "docker save ${imageName}-slim | gzip > ${archiveName}-slim.tar.gz")
+        archiveArtifacts artifacts: "${archiveName}-slim.tar.gz", onlyIfSuccessful: true
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,9 +65,9 @@ node('ubuntu-zion') {
     stage('Build') {
       gitHub.statusUpdate commitId, 'pending', 'build', 'Build is running'
 
-      imageId = buildImage(imageName)
+      imageId = buildImage('Dockerfile', imageName)
 
-      slimImageId = buildImage("${imageName}-slim")
+      slimImageId = buildImage('Dockerfile.slim', "${imageName}-slim")
 
       if (currentBuild.result == 'FAILURE') {
         gitHub.statusUpdate commitId, 'failure', 'build', 'Build failed'
@@ -199,8 +199,8 @@ def readVersion() {
   error 'Could not determine version.'
 }
 
-def buildImage(imageName) {
-  OsTools.runSafe(this, "docker build --quiet --no-cache -f Dockerfile --tag ${imageName} .")
+def buildImage(dockerFile, imageName) {
+  OsTools.runSafe(this, "docker build --quiet --no-cache -f ${dockerFile} --tag ${imageName} .")
     .split(':')[1]
 }
 

--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ are supported.
 
 ## Extending the Nexus IQ Server Image
 
-If you would like to use this image as the basis for another image that adds additional packages, e.g. `git` for SCM
-integration, take note that different versions of the image provide different package managers:
+If you would like to use this image as the basis for another image that adds additional packages,
+take note that different versions of the image provide different package managers:
 
 * Version 125 and newer provide `microdnf` as package manager.
 * Version 101 and newer provide `dnf` as package manager.
@@ -219,6 +219,14 @@ We are using `rspec` as test framework. `serverspec` provides a docker backend (
  (e.g. yum, apt,...).
 
     rspec [--backtrace] spec/Dockerfile_spec.rb
+    
+## Alternative Slim Docker Image
+
+The default Dockerfile includes:
+* `git` for enhanced SCM Integrations
+
+If you want an image without the extra tooling already installed, use the slim tag of the image:
+`sonatype/nexus-iq-server:<version>-slim`, which can also be `sonatype/nexus-iq-server:latest-slim`.
 
 ## Red Hat Certified Image
 


### PR DESCRIPTION
Additionally produce another docker image that excludes `git` binary and tag it as `<version>-slim` and `latest-slim`, so users can leave out extra tooling if they choose.

JIRA: https://issues.sonatype.org/browse/INT-6717
Build: https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/docker-nexus-iq-server-feature/job/INT-6717-alternative-slim-image/

Have a look at the build and notice the 2 artifacts, IQ report with 2 occurrences: one for each image, etc. 👍 