### PR TITLE
Disable logs for JSON schema Validation CycloneDX

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -22,6 +22,7 @@ logging:
     org.eclipse.birt.report.engine.layout.pdf.font.FontConfigReader: WARN
     org.eclipse.jetty: INFO
     org.apache.shiro.web.filter.authc.BasicHttpAuthenticationFilter: INFO
+    com.networknt.schema: ERROR
     com.sonatype.insight.audit:
       appenders:
       - type: file

--- a/config.yml
+++ b/config.yml
@@ -22,7 +22,7 @@ logging:
     org.eclipse.birt.report.engine.layout.pdf.font.FontConfigReader: WARN
     org.eclipse.jetty: INFO
     org.apache.shiro.web.filter.authc.BasicHttpAuthenticationFilter: INFO
-    com.networknt.schema: ERROR
+    com.networknt.schema: OFF
     com.sonatype.insight.audit:
       appenders:
       - type: file


### PR DESCRIPTION
This PR disables the logs for JSON schema validation when scanning SBOMs