### PR TITLE
INT-6796 new red hat build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .idea/
 Berksfile.lock
 build/
+*.log
+artifacts
+temp-auth.json

--- a/build_red_hat_image.sh
+++ b/build_red_hat_image.sh
@@ -19,16 +19,20 @@
 #   * https://github.com/redhat-openshift-ecosystem/openshift-preflight
 #   * https://podman.io/
 # * environment variables:
-#   * IMAGE name of the docker image to build for the red hat registry
 #   * VERSION of the docker image  to build for the red hat registry
-#   * PROJECT_ID from red hat config page for image
-#   * CERT_PROJECT_ID from the url to red hat config page for image
 #   * REGISTRY_PASSWORD from red hat config page for image
 #   * API_TOKEN from red hat token/account page for API access
-#   * DOCKERFILE to use to build the red hat image
 
 set -x # log commands as they execute
 set -e # stop execution on the first failed command
+
+IMAGE=nexus-iq-server
+DOCKERFILE=Dockerfile.rh
+
+# from config/scanning page at red hat
+PROJECT_ID=ospid-12731870-d048-49fc-b877-6e5316ae0d11
+# from url of project at red hat
+CERT_PROJECT_ID=5e61602c2f3c1acdd05f61d3
 
 AUTHFILE=temp-auth.json
 

--- a/build_red_hat_image.sh
+++ b/build_red_hat_image.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2017-present Sonatype, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# prerequisites:
+# * software:
+#   * https://github.com/redhat-openshift-ecosystem/openshift-preflight
+#   * https://podman.io/
+# * environment variables:
+#   * IMAGE name of the docker image to build for the red hat registry
+#   * VERSION of the docker image  to build for the red hat registry
+#   * PROJECT_ID from red hat config page for image
+#   * CERT_PROJECT_ID from the url to red hat config page for image
+#   * REGISTRY_PASSWORD from red hat config page for image
+#   * API_TOKEN from red hat token/account page for API access
+#   * DOCKERFILE to use to build the red hat image
+
+set -x # log commands as they execute
+set -e # stop execution on the first failed command
+
+AUTHFILE=temp-auth.json
+
+podman login scan.connect.redhat.com -u unused \
+       --password ${REGISTRY_PASSWORD} \
+       --authfile=${AUTHFILE}
+
+podman build \
+    -f ${DOCKERFILE} \
+    -t scan.connect.redhat.com/${PROJECT_ID}/${IMAGE}:${VERSION}
+
+podman push scan.connect.redhat.com/${PROJECT_ID}/${IMAGE}:${VERSION}
+
+preflight check container \
+    scan.connect.redhat.com/${PROJECT_ID}/${IMAGE}:${VERSION} \
+    --docker-config=${AUTHFILE} \
+    --submit \
+    --certification-project-id=${CERT_PROJECT_ID} \
+    --pyxis-api-token=${API_TOKEN}
+
+rm $AUTHFILE

--- a/build_red_hat_image.sh
+++ b/build_red_hat_image.sh
@@ -33,20 +33,20 @@ set -e # stop execution on the first failed command
 AUTHFILE=temp-auth.json
 
 podman login scan.connect.redhat.com -u unused \
-       --password ${REGISTRY_PASSWORD} \
-       --authfile=${AUTHFILE}
+       --password "${REGISTRY_PASSWORD}" \
+       --authfile "${AUTHFILE}"
 
 podman build \
-    -f ${DOCKERFILE} \
-    -t scan.connect.redhat.com/${PROJECT_ID}/${IMAGE}:${VERSION}
+       -f "${DOCKERFILE}" \
+       -t "scan.connect.redhat.com/${PROJECT_ID}/${IMAGE}:${VERSION}"
 
-podman push scan.connect.redhat.com/${PROJECT_ID}/${IMAGE}:${VERSION}
+podman push "scan.connect.redhat.com/${PROJECT_ID}/${IMAGE}:${VERSION}"
 
 preflight check container \
-    scan.connect.redhat.com/${PROJECT_ID}/${IMAGE}:${VERSION} \
-    --docker-config=${AUTHFILE} \
-    --submit \
-    --certification-project-id=${CERT_PROJECT_ID} \
-    --pyxis-api-token=${API_TOKEN}
+          "scan.connect.redhat.com/${PROJECT_ID}/${IMAGE}:${VERSION}" \
+          --docker-config="${AUTHFILE}" \
+          --submit \
+          --certification-project-id="${CERT_PROJECT_ID}" \
+          --pyxis-api-token="${API_TOKEN}"
 
 rm $AUTHFILE


### PR DESCRIPTION
Add the start of a script to build and scan the red hat image.

JIRA: https://issues.sonatype.org/browse/INT-6796
Build: https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/docker-nexus-iq-server-feature/job/INT-6796-new-red-hat-build/