### PR TITLE
INT-6885 move to the iq-specific jenkins secret

### DIFF
--- a/Jenkinsfile.rh
+++ b/Jenkinsfile.rh
@@ -41,7 +41,7 @@ node('ubuntu-zion') {
     stage('Build') {
       withCredentials([
         string(
-          credentialsId: 'red-hat-scan-registry-password',
+          credentialsId: 'red-hat-scan-registry-password-nexus-iq-server',
           variable: 'REGISTRY_PASSWORD'),
         string(
           credentialsId: 'red-hat-api-token',


### PR DESCRIPTION
It turns out that secret is specific to the nexus-iq-server image, so it should have been named accordingly, so I can also create one for nexus-repository-server.

JIRA: https://issues.sonatype.org/browse/INT-6885