### PR TITLE
INT-7032 build red hat snapshot

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -153,7 +153,7 @@ node('ubuntu-zion') {
         archiveArtifacts artifacts: "${archiveName}-slim.tar.gz", onlyIfSuccessful: true
 
         OsTools.runSafe(this, "docker save ${imageName}-redhat | gzip > ${archiveName}-redhat.tar.gz")
-        archiveArtifacts artifacts: "${archiveName}-slim.tar.gz", onlyIfSuccessful: true
+        archiveArtifacts artifacts: "${archiveName}-redhat.tar.gz", onlyIfSuccessful: true
       }
     }
 


### PR DESCRIPTION
Have the build for the IQ docker image build, test, and evaluate the Red Hat version as well, since it's very similar. Policy violations that show up in one almost always show up in the others, so this can make all the occurences visible, and allow one batch of waivers or remediations for all the images.
Note: This build doesn't push the Red Hat image anywhere. The Red Hat image is built, certified, and published to the Red Hat registry using this same repository but another build with special tooling: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Red%20Hat/job/docker-nexus-iq-red-hat-release/

JIRA: https://issues.sonatype.org/browse/INT-7032
Build: https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/docker-nexus-iq-server-feature/job/INT-7032-build-red-hat-snapshot/