### PR TITLE
Fix whitespace in upgrades

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,6 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-854
 # Build parameters
 ARG IQ_SERVER_VERSION=1.142.0-02
 ARG IQ_SERVER_SHA256=c3c1aa2d2a04e813ed76ce5691d0026bfa9958e61dfa941bfc22935a112c09a5
-
-
-
-
-
-
-
 ARG TEMP="/tmp/work"
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
 ARG SONATYPE_WORK="/sonatype-work"

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -17,9 +17,6 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-854
 # Build parameters
 ARG IQ_SERVER_VERSION=1.142.0-02
 ARG IQ_SERVER_SHA256=c3c1aa2d2a04e813ed76ce5691d0026bfa9958e61dfa941bfc22935a112c09a5
-
-
-
 ARG TEMP="/tmp/work"
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
 ARG SONATYPE_WORK="/sonatype-work"

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -17,13 +17,6 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-751
 # Build parameters
 ARG IQ_SERVER_VERSION=1.142.0-02
 ARG IQ_SERVER_SHA256=c3c1aa2d2a04e813ed76ce5691d0026bfa9958e61dfa941bfc22935a112c09a5
-
-
-
-
-
-
-
 ARG TEMP="/tmp/work"
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
 ARG SONATYPE_WORK="/sonatype-work"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,8 +34,11 @@ node('ubuntu-zion') {
     if (env.releaseBuild_NAME) {
       stage('Init IQ Version & Sha') {
         nexusIqVersion = getVersionFromBuildName(env.releaseBuild_NAME)
-        nexusIqSha = readBuildArtifact('insight/insight-brain/release', env.releaseBuild_NUMBER,
-          "artifacts/nexus-iq-server-${nexusIqVersion}-bundle.tar.gz.sha256")
+        nexusIqSha = readBuildArtifact(
+          'insight/insight-brain/release',
+          env.releaseBuild_NUMBER,
+          "artifacts/nexus-iq-server-${nexusIqVersion}-bundle.tar.gz.sha256"
+        ).trim()
       }
     }
     stage('Preparation') {


### PR DESCRIPTION
Every release added an unnecessary empty line after the SHA line that it updated.

Build: https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/docker-nexus-iq-server-feature/job/fix-whitespace-in-upgrades/