### PR TITLE
use the latest image instead of trying to update with each release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-854
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.143.0-01

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-854
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.143.0-01

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-751
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.143.0-01


### PR DESCRIPTION
Similar to what repo has, we're trying to use the last image. Thanks for noting that @nblair 

https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/docker-nexus-iq-server-feature/job/user_last_ubi_image/