### PR TITLE
Add Docker stop with timeout command to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,15 @@ To get the assigned port or check if the server is running use:
 
     docker ps --filter "name=nexus-iq-server"
     
-When stopping, be sure to allow sufficient time for the databases to fully shut down.  
+When **stopping**, be sure to allow sufficient time for the databases to fully shut down.  
 
 ```
 docker stop --time=180 <CONTAINER_NAME>
+```
+If running version 118 or earlier, then use the following approach (direct SIGTERM) for stopping the container:
+
+```
+docker exec -ti <CONTAINER_NAME> bash -c 'kill -TERM "$(cat /sonatype-work/lock | cut -d"@" -f1)"'
 ```
 
 ## Product License Installation

--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ or to let docker assign available ports use:
 To get the assigned port or check if the server is running use:
 
     docker ps --filter "name=nexus-iq-server"
+    
+When stopping, be sure to allow sufficient time for the databases to fully shut down.  
+
+```
+docker stop --time=180 <CONTAINER_NAME>
+```
 
 ## Product License Installation
 


### PR DESCRIPTION
Customers need to be advised to issue the docker stop with a sufficient timeout, as too often we see avoidable H2 DB corruptions due to abrupt stops of the container.