### PR TITLE
Docker signing automation update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -165,14 +165,15 @@ node('ubuntu-zion-legacy') {
         def dockerHubApiToken
         OsTools.runSafe(this, "mkdir -p '${env.WORKSPACE_TMP}/.dockerConfig'")
         OsTools.runSafe(this, "cp -n '${env.HOME}/.docker/config.json' '${env.WORKSPACE_TMP}/.dockerConfig' || true")
-        withEnv(["DOCKER_CONFIG=${env.WORKSPACE_TMP}/.dockerConfig"]) {
+        withEnv(["DOCKER_CONFIG=${env.WORKSPACE_TMP}/.dockerConfig", 'DOCKER_CONTENT_TRUST=1']) {
           withCredentials([
               string(credentialsId: 'nexus-iq-server_dct_reg_pw', variable: 'DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE'),
-              file(credentialsId: 'nexus-iq-server_dct_gun_key', variable: 'REPOSITORY_KEY'),
+              string(credentialsId: 'sonatype_docker_root_pw', variable: 'DOCKER_CONTENT_TRUST_ROOT_PASSPHRASE'),
+              file(credentialsId: 'nexus-iq-server_dct_gun_key', variable: 'DELEGATION_KEY'),
+              file(credentialsId: 'sonatype_docker_root_public_key', variable: 'PUBLIC_KEY'),
               [$class: 'UsernamePasswordMultiBinding', credentialsId: 'docker-hub-credentials',
                usernameVariable: 'DOCKERHUB_API_USERNAME', passwordVariable: 'DOCKERHUB_API_PASSWORD']
           ]) {
-            OsTools.runSafe(this, 'docker trust key load $REPOSITORY_KEY --name sonatype')
 
             OsTools.runSafe(this, "docker tag ${imageId} ${organization}/${dockerHubRepository}:${version}")
             OsTools.runSafe(this, "docker tag ${imageId} ${organization}/${dockerHubRepository}:latest")
@@ -182,6 +183,14 @@ node('ubuntu-zion-legacy') {
             OsTools.runSafe(this, """
             docker login --username ${env.DOCKERHUB_API_USERNAME} --password ${env.DOCKERHUB_API_PASSWORD}
             """)
+
+            // Add delegation private key
+            OsTools.runSafe(this, 'docker trust key load $DELEGATION_KEY --name sonatype')
+
+            // Add delegation public key
+            OsTools.runSafe(this, "docker trust signer add -key $PUBLIC_KEY sonatype ${organization}/${dockerHubRepository}")
+
+            // Sign the images
             OsTools.runSafe(this, "docker trust sign ${organization}/${dockerHubRepository}:${version}")
             OsTools.runSafe(this, "docker trust sign ${organization}/${dockerHubRepository}:latest")
             OsTools.runSafe(this, "docker trust sign ${organization}/${dockerHubRepository}:${version}-slim")


### PR DESCRIPTION
Trying to follow the steps from https://docs.docker.com/engine/security/trust/trust_automation/

Possibly still don't have the right set of keys, but they are all in Jenkins we just need to figure out what is what.

Turned `DOCKER_CONTENT_TRUST=1` back on.  Can't hurt.