### PR TITLE
POC - Use dockerized build pipelne

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ LABEL name="Nexus IQ Server image" \
 USER root
 
 # For testing
+RUN yum install which -y
 RUN microdnf update -y \
 && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-devel \
 && microdnf install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ LABEL name="Nexus IQ Server image" \
 USER root
 
 # For testing
-RUN yum install which -y
+RUN microdnf install which -y
 RUN microdnf update -y \
 && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-devel \
 && microdnf install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,10 +51,9 @@ LABEL name="Nexus IQ Server image" \
 USER root
 
 # For testing
-RUN microdnf install which -y
 RUN microdnf update -y \
 && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-devel \
-&& microdnf install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git \
+&& microdnf install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git which \
 && microdnf clean all
 
 # Create folders

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ dockerizedBuildPipeline(
   buildAndTest: {
     // TODO add tests
   },
+  archiveArtifacts: '**/dist/*',
   testResults: ['**/validate-expectations-results.xml'],
   lint: {
     hadolint(['Dockerfile'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,9 +23,9 @@ dockerizedBuildPipeline(
   },
   buildAndTest: {
     validateExpectations([
-          new Expectation('javaVersion', 'java', '-version', 'openjdk version "1.8.0_342"')
-          /* new Expectation('userGroups', 'id', '', 'uid=1000(nexus) gid=1000(nexus) groups=1000(nexus)'),
-          new Expectation('homeDirectory', 'pwd', '', '/opt/sonatype/nexus-iq-server'),
+          new Expectation('javaVersion', 'java', '-version', 'openjdk version "1.8.0_362"'),
+          new Expectation('userGroups', 'id', '', 'uid=1000(nexus) gid=1000(nexus) groups=1000(nexus)')
+          /*new Expectation('homeDirectory', 'pwd', '', '/opt/sonatype/nexus-iq-server'),
           new Expectation('installDirectory', '/var/log/nexus-iq-server/', '', 'Is a directory'),
           new Expectation('configDirectory', '/etc/nexus-iq-server/', '', 'Is a directory'),
           new Expectation('configFile', 'ls', '/etc/nexus-iq-server', 'config.yml') */

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,12 +23,13 @@ dockerizedBuildPipeline(
   },
   buildAndTest: {
     validateExpectations([
-          new Expectation('javaVersion', 'java', '-version', 'openjdk version "1.8.0_342"'),
-          new Expectation('userGroups', 'id', '', 'uid=1000(nexus) gid=1000(nexus) groups=1000(nexus)'),
+          new Expectation('javaVersion', 'java', '-version', 'openjdk version "1.8.0_342"')
+          /* new Expectation('userGroups', 'id', '', 'uid=1000(nexus) gid=1000(nexus) groups=1000(nexus)'),
           new Expectation('homeDirectory', 'pwd', '', '/opt/sonatype/nexus-iq-server'),
           new Expectation('installDirectory', '/var/log/nexus-iq-server/', '', 'Is a directory'),
           new Expectation('configDirectory', '/etc/nexus-iq-server/', '', 'Is a directory'),
-          new Expectation('configFile', 'ls', '/etc/nexus-iq-server', 'config.yml')])
+          new Expectation('configFile', 'ls', '/etc/nexus-iq-server', 'config.yml') */
+      ])
   },
   testResults: ['**/validate-expectations-results.xml'],
   vulnerabilityScan: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Library(['private-pipeline-library', 'jenkins-shared@test-expectations', 'iq-pipeline-library']) _
+@Library(['private-pipeline-library', 'jenkins-shared', 'iq-pipeline-library']) _
 
 import com.sonatype.jenkins.shared.Expectation
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ dockerizedBuildPipeline(
   buildAndTest: {
     validateExpectations([
           new Expectation('javaVersion', 'java', '-version', 'openjdk version "1.8.0_362"'),
-          new Expectation('userGroups', 'id', '', 'uid=1000(nexus) gid=1000(nexus) groups=1000(nexus)')
+          new Expectation('userGroups', 'id', '', 'uid=1000(nexus) gid=1000(nexus) groups=1000(nexus)'),
           new Expectation('homeDirectory', 'pwd', '', '/opt/sonatype/nexus-iq-server'),
           new Expectation('installDirectory', '/var/log/nexus-iq-server/', '', 'Is a directory'),
           new Expectation('configDirectory', '/etc/nexus-iq-server/', '', 'Is a directory'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,12 +22,14 @@ dockerizedBuildPipeline(
     githubStatusUpdate('pending')
   },
   postPrepareImage: {
+    dir('build') {
     runSafely '''docker save sonatype/nexus-iq-server | gzip > docker-nexus-iq-server.tar.gz'''
+    }
   },
   buildAndTest: {
     // TODO add tests
   },
-  archiveArtifacts: '*',
+  archiveArtifacts: 'build/*.tar.gz',
   //testResults: ['**/validate-expectations-results.xml'],
   skipVulnerabilityScan: true,
   /* lint: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,13 @@ dockerizedBuildPipeline(
     hadolint(['Dockerfile'])
   },
   buildAndTest: {
-    // TODO add tests
+    validateExpectations([
+          new Expectation('javaVersion', 'java', '-version', 'openjdk version "1.8.0_342"'),
+          new Expectation('userGroups', 'id', '', 'uid=1000(nexus) gid=1000(nexus) groups=1000(nexus)'),
+          new Expectation('homeDirectory', 'pwd', '', '/opt/sonatype/nexus-iq-server'),
+          new Expectation('installDirectory', '/var/log/nexus-iq-server/', '', 'Is a directory'),
+          new Expectation('configDirectory', '/etc/nexus-iq-server/', '', 'Is a directory'),
+          new Expectation('configFile', 'ls', '/etc/nexus-iq-server', 'config.yml')])
   },
   testResults: ['**/validate-expectations-results.xml'],
   vulnerabilityScan: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,6 @@ import com.sonatype.jenkins.shared.Expectation
 dockerizedBuildPipeline(
   lint: {
     hadolint(['Dockerfile'])
-    recordIssues(failOnError: false)
   },
   buildAndTest: {
     validateExpectations([

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ dockerizedBuildPipeline(
       iqApplication: 'docker-nexus-iq-server',
       iqScanPatterns: [[scanPattern: "container:${env.DOCKER_IMAGE_ID}"]],
       iqStage: 'develop')
-  }
+  },
   onSuccess: {
     githubStatusUpdate('success')
   },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ dockerizedBuildPipeline(
   buildAndTest: {
     // TODO add tests
   },
-  archiveArtifacts: '**/dist/*',
+  archiveArtifacts: '*',
   //testResults: ['**/validate-expectations-results.xml'],
   skipVulnerabilityScan: true,
   /* lint: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ dockerizedBuildPipeline(
   },
   buildAndTest: {
     validateExpectations([
-          new Expectation('javaVersion', 'java', '-version', 'openjdk version "1.8.0_362"'),
+          new Expectation('javaVersion', 'java', '-version', /openjdk version \"1.8.0_\d*\"/),
           new Expectation('userGroups', 'id', 'nexus', 'uid=1000(nexus) gid=1000(nexus) groups=1000(nexus)'),
           new Expectation('homeDirectory', 'pwd', '', '/opt/sonatype/nexus-iq-server'),
           new Expectation('installDirectory', 'test', '-d /var/log/nexus-iq-server/ && echo \"directory exists\"', 'directory exists'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,8 +26,7 @@ dockerizedBuildPipeline(
           new Expectation('javaVersion', 'java', '-version', 'openjdk version "1.8.0_362"'),
           new Expectation('userGroups', 'id', '', 'uid=1000(nexus) gid=1000(nexus) groups=1000(nexus)'),
           new Expectation('homeDirectory', 'pwd', '', '/opt/sonatype/nexus-iq-server'),
-          new Expectation('installDirectory', '/var/log/nexus-iq-server/', '', 'Is a directory'),
-          new Expectation('configDirectory', '/etc/nexus-iq-server/', '', 'Is a directory'),
+          new Expectation('installDirectory', 'test', '-d /var/log/nexus-iq-server/ && echo \"directory exists\"', 'directory exists'),
           new Expectation('configFile', 'ls', '/etc/nexus-iq-server', 'config.yml')
       ])
   },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,26 +18,17 @@
 import com.sonatype.jenkins.shared.Expectation
 
 dockerizedBuildPipeline(
-  prepare: {
-    githubStatusUpdate('pending')
+  lint: {
+    hadolint(['Dockerfile'])
   },
   buildAndTest: {
     // TODO add tests
   },
   testResults: ['**/validate-expectations-results.xml'],
-  lint: {
-    hadolint(['Dockerfile'])
-  },
   vulnerabilityScan: {
     nexusPolicyEvaluation(
       iqApplication: 'docker-nexus-iq-server',
       iqScanPatterns: [[scanPattern: "container:${env.DOCKER_IMAGE_ID}"]],
       iqStage: 'develop')
-  },
-  onSuccess: {
-    githubStatusUpdate('success')
-  },
-  onFailure: {
-    githubStatusUpdate('failure')
   }
 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,7 @@ import com.sonatype.jenkins.shared.Expectation
 dockerizedBuildPipeline(
   lint: {
     hadolint(['Dockerfile'])
+    recordIssues(failOnError: false)
   },
   buildAndTest: {
     validateExpectations([

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ dockerizedBuildPipeline(
     // TODO add tests
   },
   archiveArtifacts: '**/dist/*',
-  testResults: ['**/validate-expectations-results.xml'],
+  //testResults: ['**/validate-expectations-results.xml'],
   skipVulnerabilityScan: true,
   /* lint: {
     hadolint(['Dockerfile'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Library(['private-pipeline-library', 'jenkins-shared']) _
+@Library(['private-pipeline-library', 'jenkins-shared', 'iq-pipeline-library']) _
 
 import com.sonatype.jenkins.shared.Expectation
 
@@ -36,5 +36,11 @@ dockerizedBuildPipeline(
       iqApplication: 'docker-nexus-iq-server',
       iqScanPatterns: [[scanPattern: "container:${env.DOCKER_IMAGE_ID}"]],
       iqStage: 'develop')
+  },
+  onSuccess: {
+    buildNotifications(currentBuild, env)
+  },
+  onFailure: {
+    buildNotifications(currentBuild, env)
   }
 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ dockerizedBuildPipeline(
   },
   buildAndTest: {
     // TODO add tests
+    runSafely '''docker save sonatype/nexus-iq-server | gzip docker-nexus-iq-server.tar.gz'''
   },
   archiveArtifacts: '*',
   //testResults: ['**/validate-expectations-results.xml'],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,15 +26,16 @@ dockerizedBuildPipeline(
   },
   archiveArtifacts: '**/dist/*',
   testResults: ['**/validate-expectations-results.xml'],
-  lint: {
+  skipVulnerabilityScan: true,
+  /* lint: {
     hadolint(['Dockerfile'])
-  },
-  vulnerabilityScan: {
+  }, */
+  /* vulnerabilityScan: {
     nexusPolicyEvaluation(
       iqApplication: 'docker-nexus-iq-server',
       iqScanPatterns: [[scanPattern: "container:${env.DOCKER_IMAGE_ID}"]],
       iqStage: 'develop')
-  },
+  }, */
   onSuccess: {
     githubStatusUpdate('success')
   },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,10 +25,10 @@ dockerizedBuildPipeline(
     validateExpectations([
           new Expectation('javaVersion', 'java', '-version', 'openjdk version "1.8.0_362"'),
           new Expectation('userGroups', 'id', '', 'uid=1000(nexus) gid=1000(nexus) groups=1000(nexus)')
-          /*new Expectation('homeDirectory', 'pwd', '', '/opt/sonatype/nexus-iq-server'),
+          new Expectation('homeDirectory', 'pwd', '', '/opt/sonatype/nexus-iq-server'),
           new Expectation('installDirectory', '/var/log/nexus-iq-server/', '', 'Is a directory'),
           new Expectation('configDirectory', '/etc/nexus-iq-server/', '', 'Is a directory'),
-          new Expectation('configFile', 'ls', '/etc/nexus-iq-server', 'config.yml') */
+          new Expectation('configFile', 'ls', '/etc/nexus-iq-server', 'config.yml')
       ])
   },
   testResults: ['**/validate-expectations-results.xml'],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,26 +21,19 @@ dockerizedBuildPipeline(
   prepare: {
     githubStatusUpdate('pending')
   },
-  postPrepareImage: {
-    dir('build') {
-    runSafely '''docker save sonatype/nexus-iq-server | gzip > docker-nexus-iq-server.tar.gz'''
-    }
-  },
   buildAndTest: {
     // TODO add tests
   },
-  archiveArtifacts: 'build/*.tar.gz',
-  //testResults: ['**/validate-expectations-results.xml'],
-  skipVulnerabilityScan: true,
-  /* lint: {
+  testResults: ['**/validate-expectations-results.xml'],
+  lint: {
     hadolint(['Dockerfile'])
-  }, */
-  /* vulnerabilityScan: {
+  },
+  vulnerabilityScan: {
     nexusPolicyEvaluation(
       iqApplication: 'docker-nexus-iq-server',
       iqScanPatterns: [[scanPattern: "container:${env.DOCKER_IMAGE_ID}"]],
       iqStage: 'develop')
-  }, */
+  },
   onSuccess: {
     githubStatusUpdate('success')
   },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,9 +38,9 @@ dockerizedBuildPipeline(
       iqStage: 'develop')
   },
   onSuccess: {
-    //buildNotifications(currentBuild, env)
+    buildNotifications(currentBuild, env)
   },
   onFailure: {
-    //buildNotifications(currentBuild, env)
+    buildNotifications(currentBuild, env)
   }
 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,9 +38,9 @@ dockerizedBuildPipeline(
       iqStage: 'develop')
   },
   onSuccess: {
-    buildNotifications(currentBuild, env)
+    //buildNotifications(currentBuild, env)
   },
   onFailure: {
-    buildNotifications(currentBuild, env)
+    //buildNotifications(currentBuild, env)
   }
 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,276 +14,30 @@
  * limitations under the License.
  */
 @Library(['private-pipeline-library', 'jenkins-shared']) _
-import com.sonatype.jenkins.pipeline.GitHub
-import com.sonatype.jenkins.pipeline.OsTools
 
-node('ubuntu-zion-legacy') {
-  def commitId, commitDate, version, branch, dockerFileLocations, nexusIqVersion, nexusIqSha
-  def imageId, slimImageId, redHatImageId
-  def organization = 'sonatype',
-      gitHubRepository = 'docker-nexus-iq-server',
-      credentialsId = 'sonaype-ci-github-access-token',
-      imageName = 'sonatype/nexus-iq-server',
-      archiveName = 'docker-nexus-iq-server',
-      iqApplicationId = 'docker-nexus-iq-server',
-      dockerHubRepository = 'nexus-iq-server',
-      tarName = 'docker-nexus-iq-server.tar'
-  GitHub gitHub
+import com.sonatype.jenkins.shared.Expectation
 
-  try {
-    if (env.releaseBuild_NAME) {
-      stage('Init IQ Version & Sha') {
-        nexusIqVersion = getVersionFromBuildName(env.releaseBuild_NAME)
-        nexusIqSha = readBuildArtifact(
-          'insight/insight-brain/release',
-          env.releaseBuild_NUMBER,
-          "artifacts/nexus-iq-server-${nexusIqVersion}-bundle.tar.gz.sha256"
-        ).trim()
-      }
-    }
-    stage('Preparation') {
-      deleteDir()
-      OsTools.runSafe(this, "docker system prune -a -f")
-
-      def checkoutDetails = checkout scm
-
-      dockerFileLocations = [
-        "${pwd()}/Dockerfile",
-        "${pwd()}/Dockerfile.slim",
-        "${pwd()}/Dockerfile.rh",
-      ]
-
-      branch = checkoutDetails.GIT_BRANCH == 'origin/master' ? 'master' : checkoutDetails.GIT_BRANCH
-      commitId = checkoutDetails.GIT_COMMIT
-      commitDate = OsTools.runSafe(this, "git show -s --format=%cd --date=format:%Y%m%d-%H%M%S ${commitId}")
-
-      OsTools.runSafe(this, 'git config --global user.email sonatype-ci@sonatype.com')
-      OsTools.runSafe(this, 'git config --global user.name Sonatype CI')
-
-      version = readVersion()
-
-      def apiToken
-      withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: credentialsId,
-                        usernameVariable: 'GITHUB_API_USERNAME', passwordVariable: 'GITHUB_API_PASSWORD']]) {
-        apiToken = env.GITHUB_API_PASSWORD
-      }
-      gitHub = new GitHub(this, "${organization}/${gitHubRepository}", apiToken)
-    }
-    if ((env.releaseBuild_NAME) && branch == 'master') {
-      stage('Update IQ Version') {
-        OsTools.runSafe(this, "git checkout ${branch}")
-        dockerFileLocations.each { updateServerVersion(it, nexusIqVersion, nexusIqSha) }
-        version = getShortVersion(nexusIqVersion)
-      }
-    }
-    stage('Build') {
-      gitHub.statusUpdate commitId, 'pending', 'build', 'Build is running'
-
-      imageId = buildImage('Dockerfile', imageName)
-
-      slimImageId = buildImage('Dockerfile.slim', "${imageName}-slim")
-
-      redHatImageId = buildImage('Dockerfile.rh', "${imageName}-redhat")
-
-      if (currentBuild.result == 'FAILURE') {
-        gitHub.statusUpdate commitId, 'failure', 'build', 'Build failed'
-        return
-      } else {
-        gitHub.statusUpdate commitId, 'success', 'build', 'Build succeeded'
-      }
-    }
-    stage('Test') {
-      gitHub.statusUpdate commitId, 'pending', 'test', 'Tests are running'
-
-      def gemInstallDirectory = getGemInstallDirectory()
-      withEnv(["PATH+GEMS=${gemInstallDirectory}/bin"]) {
-        OsTools.runSafe(this, "gem install --user-install rspec")
-        OsTools.runSafe(this, "gem install --user-install serverspec")
-        OsTools.runSafe(this, "gem install --user-install docker-api")
-        OsTools.runSafe(this, "IMAGE_ID=${imageId} rspec --backtrace --format documentation spec/Dockerfile_spec.rb")
-        OsTools.runSafe(this, "IMAGE_ID=${slimImageId} rspec --backtrace --format documentation spec/Dockerfile_spec.rb")
-        OsTools.runSafe(this, "IMAGE_ID=${redHatImageId} rspec --backtrace --format documentation spec/Dockerfile_spec.rb")
-      }
-
-      if (currentBuild.result == 'FAILURE') {
-        gitHub.statusUpdate commitId, 'failure', 'test', 'Tests failed'
-        return
-      } else {
-        gitHub.statusUpdate commitId, 'success', 'test', 'Tests succeeded'
-      }
-    }
-    stage('Evaluate') {
-      //decide which stage we are creating
-      def theStage = branch == 'master' ? (env.releaseBuild_NAME ? 'release' : 'build') : 'develop'
-
-      runEvaluation({ stage ->
-        nexusPolicyEvaluation(
-          iqStage: stage,
-          iqApplication: iqApplicationId,
-          iqScanPatterns: [
-            [scanPattern: "container:${imageName}"],
-            [scanPattern: "container:${imageName}-slim"],
-            [scanPattern: "container:${imageName}-redhat"],
-          ],
-          failBuildOnNetworkError: true)
-      }, theStage)
-    }
-
-    if (currentBuild.result == 'FAILURE') {
-      return
-    }
-    if ((env.releaseBuild_NAME) && branch == 'master') {
-      stage('Commit IQ Version Update') {
-        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: credentialsId,
-                        usernameVariable: 'GITHUB_API_USERNAME', passwordVariable: 'GITHUB_API_PASSWORD']]) {
-          def commitMessage = [
-            nexusIqVersion && nexusIqSha ? "Update IQ Server to ${nexusIqVersion}." : "",
-          ].findAll({ it }).join(' ')
-          OsTools.runSafe(this, """
-            git add .
-            git diff --exit-code --cached || git commit -m '${commitMessage}'
-            git push https://${env.GITHUB_API_USERNAME}:${env.GITHUB_API_PASSWORD}@github.com/${organization}/${gitHubRepository}.git ${branch}
-          """)
-        }
-      }
-    }
-    stage('Archive') {
-      dir('build/target') {
-        OsTools.runSafe(this, "docker save ${imageName} | gzip > ${archiveName}.tar.gz")
-        archiveArtifacts artifacts: "${archiveName}.tar.gz", onlyIfSuccessful: true
-
-        OsTools.runSafe(this, "docker save ${imageName}-slim | gzip > ${archiveName}-slim.tar.gz")
-        archiveArtifacts artifacts: "${archiveName}-slim.tar.gz", onlyIfSuccessful: true
-
-        OsTools.runSafe(this, "docker save ${imageName}-redhat | gzip > ${archiveName}-redhat.tar.gz")
-        archiveArtifacts artifacts: "${archiveName}-redhat.tar.gz", onlyIfSuccessful: true
-      }
-    }
-
-    if ((env.releaseBuild_NAME) && branch == 'master') {
-      stage('Push images') {
-        def dockerHubApiToken
-        OsTools.runSafe(this, "mkdir -p '${env.WORKSPACE_TMP}/.dockerConfig'")
-        OsTools.runSafe(this, "cp -n '${env.HOME}/.docker/config.json' '${env.WORKSPACE_TMP}/.dockerConfig' || true")
-        withEnv(["DOCKER_CONFIG=${env.WORKSPACE_TMP}/.dockerConfig", 'DOCKER_CONTENT_TRUST=1']) {
-          withCredentials([
-              file(credentialsId: 'nexus-iq-server-repository-key', variable: 'NEXUS_IQ_SERVER_REPOSITORY_KEY'),
-              file(credentialsId: 'sonatype-pub', variable: 'SONATYPE_PUB'),
-              file(credentialsId: 'sonatype-key', variable: 'SONATYPE_KEY'),
-              [$class: 'UsernamePasswordMultiBinding', credentialsId: 'docker-hub-credentials',
-               usernameVariable: 'DOCKERHUB_API_USERNAME', passwordVariable: 'DOCKERHUB_API_PASSWORD']
-          ]) {
-            OsTools.runSafe(this, """
-            docker login --username ${env.DOCKERHUB_API_USERNAME} --password ${env.DOCKERHUB_API_PASSWORD}
-            """)
-
-            // load the repository key..
-            OsTools.runSafe(this, 'docker trust key load $NEXUS_IQ_SERVER_REPOSITORY_KEY')
-
-            // load the signers private key
-            OsTools.runSafe(this, 'docker trust key load $SONATYPE_KEY')
-
-            // add signer - for this you need signers public key and repository keys password
-            withCredentials([string(credentialsId: 'nexus-iq-server_dct_reg_pw', variable: 'DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE')]) {
-              OsTools.runSafe(this, "docker trust signer add sonatype ${organization}/${dockerHubRepository} --key $SONATYPE_PUB")
-            }
-
-            OsTools.runSafe(this, "docker tag ${imageId} ${organization}/${dockerHubRepository}:${version}")
-            OsTools.runSafe(this, "docker tag ${imageId} ${organization}/${dockerHubRepository}:latest")
-            OsTools.runSafe(this, "docker tag ${slimImageId} ${organization}/${dockerHubRepository}:${version}-slim")
-            OsTools.runSafe(this, "docker tag ${slimImageId} ${organization}/${dockerHubRepository}:latest-slim")
-
-            // Sign the images
-            // Signing images also pushes them
-            withCredentials([string(credentialsId: 'sonatype-password', variable: 'DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE')]) {
-              // push the images
-              OsTools.runSafe(this, "docker image push ${organization}/${dockerHubRepository}:${version}")
-              OsTools.runSafe(this, "docker image push ${organization}/${dockerHubRepository}:latest")
-              OsTools.runSafe(this, "docker image push ${organization}/${dockerHubRepository}:${version}-slim")
-              OsTools.runSafe(this, "docker image push ${organization}/${dockerHubRepository}:latest-slim")
-            }
-
-            response = OsTools.runSafe(this, """
-            curl -X POST https://hub.docker.com/v2/users/login/ \
-              -H 'cache-control: no-cache' -H 'content-type: application/json' \
-              -d '{ "username": "${env.DOCKERHUB_API_USERNAME}", "password": "${env.DOCKERHUB_API_PASSWORD}" }'
-            """)
-            token = readJSON text: response
-            dockerHubApiToken = token.token
-
-            def readme = readFile file: 'README.md', encoding: 'UTF-8'
-            readme = readme.replaceAll("(?s)<!--.*?-->", "")
-            readme = readme.replace("\"", "\\\"")
-            readme = readme.replace("\n", "\\n")
-            readme = readme.replace("\\\$", "\\\\\$")
-            response = httpRequest customHeaders: [[name: 'authorization', value: "JWT ${dockerHubApiToken}"]],
-                acceptType: 'APPLICATION_JSON', contentType: 'APPLICATION_JSON', httpMode: 'PATCH',
-                requestBody: "{ \"full_description\": \"${readme}\" }",
-                url: "https://hub.docker.com/v2/repositories/${organization}/${dockerHubRepository}/"
-          }
-        }
-      }
-      stage('Push tags') {
-        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: credentialsId,
-                          usernameVariable: 'GITHUB_API_USERNAME', passwordVariable: 'GITHUB_API_PASSWORD']]) {
-          OsTools.runSafe(this, "git tag ${version}")
-          OsTools.runSafe(this, """
-            git push \
-            https://${env.GITHUB_API_USERNAME}:${env.GITHUB_API_PASSWORD}@github.com/${organization}/${gitHubRepository}.git \
-              ${version}
-          """)
-        }
-        OsTools.runSafe(this, "git tag -d ${version}")
-      }
-    }
-  } finally {
-    OsTools.runSafe(this, "docker logout")
-    OsTools.runSafe(this, "docker system prune -a -f")
-    OsTools.runSafe(this, 'git clean -f && git reset --hard origin/master')
+dockerizedBuildPipeline(
+  prepare: {
+    githubStatusUpdate('pending')
+  },
+  buildAndTest: {
+    // TODO add tests
+  },
+  testResults: ['**/validate-expectations-results.xml'],
+  lint: {
+    hadolint(['Dockerfile'])
+  },
+  vulnerabilityScan: {
+    nexusPolicyEvaluation(
+      iqApplication: 'docker-nexus-iq-server',
+      iqScanPatterns: [[scanPattern: "container:${env.DOCKER_IMAGE_ID}"]],
+      iqStage: 'develop')
   }
-}
-
-def readVersion() {
-  def content = readFile 'Dockerfile'
-  for (line in content.split('\n')) {
-    if (line.startsWith('ARG IQ_SERVER_VERSION=')) {
-      return getShortVersion(line.substring(22))
-    }
+  onSuccess: {
+    githubStatusUpdate('success')
+  },
+  onFailure: {
+    githubStatusUpdate('failure')
   }
-  error 'Could not determine version.'
-}
-
-String buildImage(String dockerFile, String imageName) {
-  OsTools.runSafe(this, "docker build --quiet --no-cache -f ${dockerFile} --tag ${imageName} .")
-    .split(':')[1]
-}
-
-def getShortVersion(version) {
-  return version.split('-')[0]
-}
-
-def getGemInstallDirectory() {
-  def content = OsTools.runSafe(this, "gem env")
-  for (line in content.split('\n')) {
-    if (line.startsWith('  - USER INSTALLATION DIRECTORY: ')) {
-      return line.substring(33)
-    }
-  }
-  error 'Could not determine user gem install directory.'
-}
-
-def updateServerVersion(dockerFileLocation, iqVersion, iqSha) {
-  def dockerFile = readFile(file: dockerFileLocation)
-
-  def metaShortVersionRegex = /(release=")(\d\.\d{1,3}\.\d)(" \\)/
-
-  def versionRegex = /(ARG IQ_SERVER_VERSION=)(\d\.\d{1,3}\.\d\-\d{2})/
-  def shaRegex = /(ARG IQ_SERVER_SHA256=)([A-Fa-f0-9]{64})/
-
-  dockerFile = dockerFile.replaceAll(metaShortVersionRegex,
-      "\$1${iqVersion.substring(0, iqVersion.indexOf('-'))}\$3")
-  dockerFile = dockerFile.replaceAll(versionRegex, "\$1${iqVersion}")
-  dockerFile = dockerFile.replaceAll(shaRegex, "\$1${iqSha}")
-
-  writeFile(file: dockerFileLocation, text: dockerFile)
-}
+)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Library(['private-pipeline-library', 'jenkins-shared', 'iq-pipeline-library']) _
+@Library(['private-pipeline-library', 'jenkins-shared@test-expectations', 'iq-pipeline-library']) _
 
 import com.sonatype.jenkins.shared.Expectation
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ dockerizedBuildPipeline(
     validateExpectations([
           new Expectation('javaVersion', 'java', '-version', /openjdk version \"1.8.0_\d*\"/),
           new Expectation('userGroups', 'id', 'nexus', 'uid=1000(nexus) gid=1000(nexus) groups=1000(nexus)'),
-          new Expectation('homeDirectory', 'eval', 'echo ~$nexus', '/opt/sonatype/nexus-iq-server'),
+          new Expectation('homeDirectory', 'echo', '~nexus', '/opt/sonatype/nexus-iq-server'),
           new Expectation('installDirectory', 'test', '-d /var/log/nexus-iq-server/ && echo \"directory exists\"', 'directory exists'),
           new Expectation('configFile', 'ls', '/etc/nexus-iq-server', 'config.yml')
       ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ dockerizedBuildPipeline(
     validateExpectations([
           new Expectation('javaVersion', 'java', '-version', /openjdk version \"1.8.0_\d*\"/),
           new Expectation('userGroups', 'id', 'nexus', 'uid=1000(nexus) gid=1000(nexus) groups=1000(nexus)'),
-          new Expectation('homeDirectory', 'pwd', '', '/opt/sonatype/nexus-iq-server'),
+          new Expectation('homeDirectory', 'eval', 'echo ~$nexus', '/opt/sonatype/nexus-iq-server'),
           new Expectation('installDirectory', 'test', '-d /var/log/nexus-iq-server/ && echo \"directory exists\"', 'directory exists'),
           new Expectation('configFile', 'ls', '/etc/nexus-iq-server', 'config.yml')
       ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ dockerizedBuildPipeline(
   buildAndTest: {
     validateExpectations([
           new Expectation('javaVersion', 'java', '-version', 'openjdk version "1.8.0_362"'),
-          new Expectation('userGroups', 'id', '', 'uid=1000(nexus) gid=1000(nexus) groups=1000(nexus)'),
+          new Expectation('userGroups', 'id', 'nexus', 'uid=1000(nexus) gid=1000(nexus) groups=1000(nexus)'),
           new Expectation('homeDirectory', 'pwd', '', '/opt/sonatype/nexus-iq-server'),
           new Expectation('installDirectory', 'test', '-d /var/log/nexus-iq-server/ && echo \"directory exists\"', 'directory exists'),
           new Expectation('configFile', 'ls', '/etc/nexus-iq-server', 'config.yml')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ dockerizedBuildPipeline(
     githubStatusUpdate('pending')
   },
   postPrepareImage: {
-    runSafely '''docker save sonatype/nexus-iq-server | gzip docker-nexus-iq-server.tar.gz'''
+    runSafely '''docker save sonatype/nexus-iq-server | gzip > docker-nexus-iq-server.tar.gz'''
   },
   buildAndTest: {
     // TODO add tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ dockerizedBuildPipeline(
           new Expectation('userGroups', 'id', 'nexus', 'uid=1000(nexus) gid=1000(nexus) groups=1000(nexus)'),
           new Expectation('homeDirectory', 'echo', '~nexus', '/opt/sonatype/nexus-iq-server'),
           new Expectation('installDirectory', 'test', '-d /var/log/nexus-iq-server/ && echo \"directory exists\"', 'directory exists'),
-          new Expectation('configFile', 'ls', '/etc/nexus-iq-server', 'config.yml')
+          new Expectation('configFile', 'test', '-f /etc/nexus-iq-server/config.yml && echo \"file exists\"', 'file exists')
       ])
   },
   testResults: ['**/validate-expectations-results.xml'],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,9 +21,11 @@ dockerizedBuildPipeline(
   prepare: {
     githubStatusUpdate('pending')
   },
+  postPrepareImage: {
+    runSafely '''docker save sonatype/nexus-iq-server | gzip docker-nexus-iq-server.tar.gz'''
+  },
   buildAndTest: {
     // TODO add tests
-    runSafely '''docker save sonatype/nexus-iq-server | gzip docker-nexus-iq-server.tar.gz'''
   },
   archiveArtifacts: '*',
   //testResults: ['**/validate-expectations-results.xml'],

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2017-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@Library(['private-pipeline-library', 'jenkins-shared']) _
+
+import com.sonatype.jenkins.shared.Expectation
+
+properties([
+  parameters([
+    run(name: 'releaseBuild',
+        filter: 'SUCCESSFUL',
+        projectName: 'insight/insight-brain/release',
+        description: 'The latest release of IQ Server to build the docker image')
+  ])
+])
+
+String imageName = 'sonatype/nexus-iq-server',
+String version = ''
+String checksum = ''
+
+dockerizedBuildPipeline(
+  prepare: {
+    githubStatusUpdate('pending')
+    version = getVersionFromBuildName(env.releaseBuild_NAME)
+    checksum = readBuildArtifact('insight/insight-brain/release', env.releaseBuild_NUMBER, "artifacts/nexus-iq-server-${version}-bundle.tar.gz.sha256").trim()
+    updateIQServerVersionAndChecksum(version, checksum)
+    commitAndPushChanges(version)
+  },
+  setVersion: {
+    env['VERSION'] = version.split('-')[0]
+  },
+  buildAndTest: {
+    currentBuild.displayName = "#${currentBuild.id} ${imageName}-${env.VERSION}"
+    // TODO add tests
+  },
+  testResults: ['**/validate-expectations-results.xml'],
+  lint: {
+    hadolint(['Dockerfile'])
+  },
+  vulnerabilityScan: {
+    nexusPolicyEvaluation(
+      iqApplication: 'docker-nexus-iq-server',
+      iqScanPatterns: [[scanPattern: "container:${env.DOCKER_IMAGE_ID}"]],
+      iqStage: 'release')
+  },
+  deploy: {
+    // TODO deploy to docker hub
+  },
+  postDeploy: {
+    sshagent(credentials: [sonatypeZionCredentialsId()]) {
+      sh '''git config user.email "sonatype-zion@sonatype.com"
+            git tag ${env.VERSION}
+            git push origin ${env.VERSION}'''
+    }
+  },
+  onSuccess: {
+    githubStatusUpdate('success')
+  },
+  onFailure: {
+    githubStatusUpdate('failure')
+  }
+)
+
+void updateIQServerVersionAndChecksum(String version, String checksum) {
+  def dockerFile = readFile(file: "${pwd()}/Dockerfile")
+  def versionRegex = /(ARG IQ_SERVER_VERSION=)(\d\.\d{1,3}\.\d\-\d{2})/
+  def shaRegex = /(ARG IQ_SERVER_SHA256=)([A-Fa-f0-9]{64})/
+
+  dockerFile = dockerFile.replaceAll(versionRegex, "\$1${version}")
+  dockerFile = dockerFile.replaceAll(shaRegex, "\$1${checksum}")
+
+  writeFile(file: "${pwd()}/Dockerfile", text: dockerFile)
+}
+
+void commitAndPushChanges(String version) {
+  runSafely 'git config --global push.default simple'
+  sonatypeZionGitConfig()
+  sshagent(credentials: [sonatypeZionCredentialsId()]) {
+    runSafely 'git add .'
+    runSafely "git diff --exit-code --cached || git commit -m 'Update to version ${version}'"
+
+    // pull and merge any new commits on main so that the push doesn't fail
+   runSafely 'git pull --no-rebase --no-edit origin main'
+   runSafely 'git push origin test-docker-build-pipeline'
+  }
+}

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -105,6 +105,6 @@ void commitAndPushChanges(String version) {
 
     // pull and merge any new commits on main so that the push doesn't fail
    runSafely 'git pull --no-rebase --no-edit origin main'
-   runSafely 'git push origin HEAD:main
+   runSafely 'git push origin HEAD:main'
   }
 }

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -94,6 +94,6 @@ void commitAndPushChanges(String version) {
 
     // pull and merge any new commits on main so that the push doesn't fail
    runSafely 'git pull --no-rebase --no-edit origin main'
-   runSafely 'git push origin test-docker-build-pipeline'
+   runSafely 'git push origin HEAD:main
   }
 }

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -46,6 +46,7 @@ dockerizedBuildPipeline(
   },
   lint: {
     hadolint(['Dockerfile'])
+    recordIssues(failOnError: false)
   },
   postPrepareImage: {
     dir('build') {

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -58,7 +58,11 @@ dockerizedBuildPipeline(
       iqStage: 'release')
   },
   deploy: {
-    // TODO deploy to docker hub
+    withSonatypeDockerRegistry() {
+      sh """docker tag $DOCKER_IMAGE_ID ${sonatypeDockerRegistryId()}/${imageName}-${env.BUILD_NUMBER}
+            docker push ${sonatypeDockerRegistryId()}/${imageName}-${env.BUILD_NUMBER}
+            docker rmi ${sonatypeDockerRegistryId()}/${imageName}-${env.BUILD_NUMBER}"""
+    }
   },
   postDeploy: {
     sshagent(credentials: [sonatypeZionCredentialsId()]) {

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -46,7 +46,6 @@ dockerizedBuildPipeline(
   },
   lint: {
     hadolint(['Dockerfile'])
-    recordIssues(failOnError: false)
   },
   postPrepareImage: {
     dir('build') {

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -43,6 +43,12 @@ dockerizedBuildPipeline(
   setVersion: {
     env['VERSION'] = version.split('-')[0]
   },
+  postPrepareImage: {
+    dir('build') {
+      runSafely "docker save ${imageName} | gzip > docker-nexus-iq-server-${env.VERSION}.tar.gz"
+    }
+  },
+  archiveArtifacts: 'build/*.tar.gz',
   buildAndTest: {
     currentBuild.displayName = "#${currentBuild.id} ${imageName}-${env.VERSION}"
     // TODO add tests

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -28,6 +28,7 @@ properties([
 ])
 
 String imageName = 'sonatype/nexus-iq-server',
+String dockerHubRepository = 'nexus-iq-server',
 String version = ''
 String checksum = ''
 
@@ -64,11 +65,7 @@ dockerizedBuildPipeline(
       iqStage: 'release')
   },
   deploy: {
-    withSonatypeDockerRegistry() {
-      sh """docker tag $DOCKER_IMAGE_ID ${sonatypeDockerRegistryId()}/${imageName}-${env.BUILD_NUMBER}
-            docker push ${sonatypeDockerRegistryId()}/${imageName}-${env.BUILD_NUMBER}
-            docker rmi ${sonatypeDockerRegistryId()}/${imageName}-${env.BUILD_NUMBER}"""
-    }
+    pushImage()
   },
   postDeploy: {
     sshagent(credentials: [sonatypeZionCredentialsId()]) {
@@ -106,5 +103,55 @@ void commitAndPushChanges(String version) {
     // pull and merge any new commits on main so that the push doesn't fail
    runSafely 'git pull --no-rebase --no-edit origin main'
    runSafely 'git push origin HEAD:main'
+  }
+}
+
+void pushImage() {
+  runSafely "mkdir -p '${env.WORKSPACE_TMP}/.dockerConfig'"
+  runSafely "cp -n '${env.HOME}/.docker/config.json' '${env.WORKSPACE_TMP}/.dockerConfig' || true"
+
+  withEnv(["DOCKER_CONFIG=${env.WORKSPACE_TMP}/.dockerConfig", 'DOCKER_CONTENT_TRUST=1']) {
+    withCredentials([
+      file(credentialsId: 'nexus-iq-server-repository-key', variable: 'NEXUS_IQ_SERVER_REPOSITORY_KEY'),
+      file(credentialsId: 'sonatype-pub', variable: 'SONATYPE_PUB'),
+      file(credentialsId: 'sonatype-key', variable: 'SONATYPE_KEY'),
+      [ $class: 'UsernamePasswordMultiBinding', credentialsId: 'docker-hub-credentials',
+        usernameVariable: 'DOCKERHUB_API_USERNAME', passwordVariable: 'DOCKERHUB_API_PASSWORD']]) {
+
+      runSafely """docker login --username ${env.DOCKERHUB_API_USERNAME} --password ${env.DOCKERHUB_API_PASSWORD}"
+                   docker trust key load $NEXUS_IQ_SERVER_REPOSITORY_KEY
+                   docker trust key load $SONATYPE_KEY"""
+
+      // add signer - for this you need signers public key and repository keys password
+      withCredentials([string(credentialsId: 'nexus-iq-server_dct_reg_pw', variable: 'DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE')]) {
+        runSafely "docker trust signer add sonatype ${organization}/${dockerHubRepository} --key $SONATYPE_PUB"
+      }
+
+      runSafely "docker tag ${imageId} ${organization}/${dockerHubRepository}:${env.VERSION}"
+      runSafely "docker tag ${imageId} ${organization}/${dockerHubRepository}:latest"
+
+      withCredentials([string(credentialsId: 'sonatype-password', variable: 'DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE')]) {
+        runSafely "docker image push ${organization}/${dockerHubRepository}:${env.VERSION}"
+        runSafely "docker image push ${organization}/${dockerHubRepository}:latest"
+      }
+
+      String response = runSafely("""curl -X POST https://hub.docker.com/v2/users/login/ \
+                                     -H 'cache-control: no-cache' -H 'content-type: application/json' \
+                                     -d '{ "username": "${env.DOCKERHUB_API_USERNAME}", "password": "${env.DOCKERHUB_API_PASSWORD}" }'
+                                  """, true)
+      def token = readJSON(text: response)
+      def dockerHubApiToken = token.token
+
+      String readme = readFile file: 'README.md', encoding: 'UTF-8'
+      readme = readme.replaceAll("(?s)<!--.*?-->", "")
+      readme = readme.replace("\"", "\\\"")
+      readme = readme.replace("\n", "\\n")
+      readme = readme.replace("\\\$", "\\\\\$")
+
+      httpRequest customHeaders: [[name: 'authorization', value: "JWT ${dockerHubApiToken}"]],
+                  acceptType: 'APPLICATION_JSON', contentType: 'APPLICATION_JSON', httpMode: 'PATCH',
+                  requestBody: "{ \"full_description\": \"${readme}\" }",
+                  url: "https://hub.docker.com/v2/repositories/${organization}/${dockerHubRepository}/"
+    }
   }
 }

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -43,6 +43,9 @@ dockerizedBuildPipeline(
   setVersion: {
     env['VERSION'] = version.split('-')[0]
   },
+  lint: {
+    hadolint(['Dockerfile'])
+  },
   postPrepareImage: {
     dir('build') {
       runSafely "docker save ${imageName} | gzip > docker-nexus-iq-server-${env.VERSION}.tar.gz"
@@ -54,9 +57,6 @@ dockerizedBuildPipeline(
     // TODO add tests
   },
   testResults: ['**/validate-expectations-results.xml'],
-  lint: {
-    hadolint(['Dockerfile'])
-  },
   vulnerabilityScan: {
     nexusPolicyEvaluation(
       iqApplication: 'docker-nexus-iq-server',

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -32,6 +32,7 @@ String version = ''
 String checksum = ''
 
 dockerizedBuildPipeline(
+  deployBranch: 'main',
   prepare: {
     githubStatusUpdate('pending')
     version = getVersionFromBuildName(env.releaseBuild_NAME)


### PR DESCRIPTION
As announced in the Build and Release slack [channel](https://sonatype.slack.com/archives/C01QWPH4HGR/p1680297070189159) the legacy Jenkins agents will be removed soon. The current build doesn't work on the modern Jenkins agent (Ruby is not installed on the modern Jenkins agent).

As mentioned in [BNR-882](https://issues.sonatype.org/browse/BNR-882), this build also has a lot of tech debt. This PR is an initial attempt at modernising this build to use the [dockerizedBuildPipeline](https://docs.sonatype.com/display/CDI/Dockerized+Build+Pipeline).

I've separated the Jenkinsfile into two, one for the main snapshot build, and the second for the release build. While there is some code duplication (the tests), the Jenkinsfiles are easier to read.

Finally, a Jenkinsfile will be needed for each docker file (e.g. slim, redhat etc).

This  POC PR outlines how the build will look using the dockerizedBuildPipeline. Also a place to ask questions or comment if something looks wrong. Also It needs to be fully tested by attempting to publish an image.