### PR TITLE
declare deployBranch variable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,11 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 @Library(['private-pipeline-library', 'jenkins-shared']) _
+
 import com.sonatype.jenkins.shared.Expectation
 
+void configureBranchJob() {
+  String projName = currentBuild.fullProjectName
+  if (projName.endsWith('main')) {
+    properties([
+      disableConcurrentBuilds(),
+      pipelineTriggers([cron('@daily')])
+    ])
+  }
+}
+
+String deployBranch = 'main'
+
+configureBranchJob()
 dockerizedBuildPipeline(
-  deployBranch: 'main',
+  deployBranch: deployBranch,
   prepare: {
     githubStatusUpdate('pending')
   },
@@ -35,14 +50,12 @@ dockerizedBuildPipeline(
       iqScanPatterns: [[scanPattern: "container:${env.DOCKER_IMAGE_ID}"]],
       iqStage: 'develop')
   },
-  onSuccess: {
-    githubStatusUpdate('success')
+  onUnstable: {
     if (env.BRANCH_NAME == deployBranch) {
       notifyChat(currentBuild: currentBuild, env: env, room: 'iq-builds')
     } 
   },
   onFailure: {
-    githubStatusUpdate('failure')
     if (env.BRANCH_NAME == deployBranch) {
       notifyChat(currentBuild: currentBuild, env: env, room: 'iq-builds')
     } 


### PR DESCRIPTION
Currently main snapshot  [build](https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/Docker-Test/job/iq-server-docker-image-build-test/job/main/1/console) is failing because `deployBranch` isn't declared. This PR 
1. Declares the variable
2. Setup cron so this build is run daily. 
3. Sends alerts for unstable/failing build.

2 & 3 means you can find out about policy violations well in advance of a release, giving you enough time to remediate them,