### PR TITLE
Remove post deploy for Docker slim image build

### DIFF
--- a/Jenkinsfile.slim.release
+++ b/Jenkinsfile.slim.release
@@ -68,13 +68,6 @@ dockerizedBuildPipeline(
   deploy: {
     pushImage(imageName)
   },
-  postDeploy: {
-    sshagent(credentials: [sonatypeZionCredentialsId()]) {
-      sonatypeZionGitConfig()
-      sh """git tag ${env.VERSION}
-            git push origin ${env.VERSION}"""
-    }
-  },
   onSuccess: {
     githubStatusUpdate('success')
   },


### PR DESCRIPTION
The docker slim image [build](https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/slim-image/job/release/) failed on the post deploy stage. It tried to create Github tags, which had already been created by the main image [build](https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/main-image/job/release/). 

Quickest solution is let only the main build create the required Github tag. 