### PR TITLE
fix(CLM-26779): Check Policy Violations for  : libx11 : 1.6.8-5.el8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ build/
 artifacts
 temp-auth.json
 build.sh
+*.iml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ USER root
 # For testing
 # hadolint ignore=DL3041
 RUN microdnf update -y \
-&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-devel \
+&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless \
 && microdnf install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git which \
 && microdnf clean all
 

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -52,7 +52,7 @@ USER root
 # For testing
 # hadolint ignore=DL3041
 RUN microdnf update -y \
-&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-devel \
+&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless \
 && microdnf install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git which\
 && microdnf clean all
 

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -52,7 +52,7 @@ USER root
 # For testing
 # hadolint ignore=DL3041
 RUN microdnf update -y \
-&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-devel \
+&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless \
 && microdnf install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync which\
 && microdnf clean all
 


### PR DESCRIPTION
Jira: https://sonatype.atlassian.net/browse/CLM-26779
Jenkins:

Default Image: https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/main-image/job/iq-server-docker-image-build-test/job/CLM-26779-check-policy-violations-for-libx11/

Certified Redhat Image: https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/redhat-image/job/iq-server-docker-slim-red-hat-build-test/job/CLM-26779-check-policy-violations-for-libx11/

Slim Image: https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/slim-image/job/iq-server-docker-slim-image-build-test/job/CLM-26779-check-policy-violations-for-libx11/

The goal of this PR is to test how changing the Dockerfile from the ubi redhat image to use the java package java-1.8.0-openjdk-headless instead of java-1.8.0-openjdk-devel.

The package java-1.8.0-openjdk-headless install unused dependencies for graphical mode in linux such as libX11 which are libraries are not being used at all in the ubi image(image does not have a graphical mode X).

Using the headless version of the java package could get rid off of unnecessary packages and at the same time potential vulnerabilities associated to these packages.