### PR TITLE
I-Day Vulberabilities Investigation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,9 +53,9 @@ USER root
 
 # For testing
 # hadolint ignore=DL3041
-RUN microdnf update -y \
+RUN microdnf --setopt=install_weak_deps=0  update -y \
 && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless \
-&& microdnf install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git which \
+&& microdnf --setopt=install_weak_deps=0 install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git which \
 && microdnf clean all
 
 # Create folders & set permissions

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,9 @@ USER root
 
 # For testing
 # hadolint ignore=DL3041
-RUN microdnf --setopt=install_weak_deps=0 upgrade-minimal -y \
+RUN microdnf --setopt=install_weak_deps=0 upgrade -y \
 && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless procps gzip unzip tar shadow-utils findutils util-linux less rsync git which \
+&& microdnf remove perl-Errno perl-interpreter perl-IO perl-libs perl-macros cups-libs\
 && microdnf clean all
 
 # Create folders & set permissions

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,6 @@ USER root
 # hadolint ignore=DL3041
 RUN microdnf --setopt=install_weak_deps=0 upgrade -y \
 && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless procps gzip unzip tar shadow-utils findutils util-linux less rsync git which \
-&& microdnf remove perl-Errno perl-interpreter perl-IO perl-libs perl-macros cups-libs\
 && microdnf clean all
 
 # Create folders & set permissions

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ USER root
 # For testing
 # hadolint ignore=DL3041
 RUN microdnf --setopt=install_weak_deps=0 update -y \
+&& microdnf --setopt=install_weak_deps=0 upgrade -y \
 && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless procps gzip unzip tar shadow-utils findutils util-linux less rsync git which \
 && microdnf clean all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,7 @@ USER root
 
 # For testing
 # hadolint ignore=DL3041
-RUN microdnf --setopt=install_weak_deps=0 update -y \
-&& microdnf --setopt=install_weak_deps=0 upgrade -y \
+RUN microdnf --setopt=install_weak_deps=0 upgrade-minimal -y \
 && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless procps gzip unzip tar shadow-utils findutils util-linux less rsync git which \
 && microdnf clean all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,9 +53,8 @@ USER root
 
 # For testing
 # hadolint ignore=DL3041
-RUN microdnf --setopt=install_weak_deps=0  update -y \
-&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless \
-&& microdnf --setopt=install_weak_deps=0 install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git which \
+RUN microdnf --setopt=install_weak_deps=0 update -y \
+&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless procps gzip unzip tar shadow-utils findutils util-linux less rsync git which \
 && microdnf clean all
 
 # Create folders & set permissions

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,7 @@ USER root
 
 # For testing
 # hadolint ignore=DL3041
-RUN microdnf --setopt=install_weak_deps=0 upgrade -y \
-&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless procps gzip unzip tar shadow-utils findutils util-linux less rsync git which \
+RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless procps gzip unzip tar shadow-utils findutils util-linux less rsync git which \
 && microdnf clean all
 
 # Create folders & set permissions

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -52,9 +52,7 @@ USER root
 
 # For testing
 # hadolint ignore=DL3041
-RUN microdnf update -y \
-&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless \
-&& microdnf install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git which\
+RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless procps gzip unzip tar shadow-utils findutils util-linux less rsync git which\
 && microdnf clean all
 
 # Create folders & set permissions

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -51,9 +51,7 @@ USER root
 
 # For testing
 # hadolint ignore=DL3041
-RUN microdnf update -y \
-&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless \
-&& microdnf install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync which\
+RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless procps gzip unzip tar shadow-utils findutils util-linux less rsync which\
 && microdnf clean all
 
 # Create folders & set permissions


### PR DESCRIPTION
It turns out you get less vulnerable components if you do not run `microdnf upgrade`. I suspect this is since we do not tag the base image (which is managed by Red Hat) so maybe upgrading the packages bundled with the base image brings in component versions that are not needed/vulnerable. 

Standard Docker image
main branch report: https://iq.sonatype.dev/assets/index.html#/applicationReport/docker-nexus-iq-server/f510e704d58248b3827cbab5575f8bab/policy 
feature branch report: https://iq.sonatype.dev/assets/index.html#/applicationReport/docker-nexus-iq-server/b15113b0767f43899270f302fd7e429e/policy 
 
Red Hat Docker image
main branch report: https://iq.sonatype.dev/assets/index.html#/applicationReport/docker-nexus-iq-server-rh/25252e5ebca241e49fe82bdb4532b880/policy 
feature branch report: https://iq.sonatype.dev/assets/index.html#/applicationReport/docker-nexus-iq-server-rh/db0e833f0a7e447fa655392fd1ef0d0b/policy 

Slim Docker image
main branch report: https://iq.sonatype.dev/assets/index.html#/applicationReport/docker-nexus-iq-server-slim/7079dc59b3c34b328b147af7f81c30c5/policy 
feature branch report: https://iq.sonatype.dev/assets/index.html#/applicationReport/docker-nexus-iq-server-slim/c5e1077481604609b6e8afcdd95a3f6e/policy 