### PR TITLE
SDEV-840: Swtich to REHL 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # hadolint ignore=DL3026
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.171.0-01

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # hadolint ignore=DL3026
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.165.0-01

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # hadolint ignore=DL3026
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.171.0-01


### PR DESCRIPTION
Upgrading to Rehl 9 will resolve policy violations for CVE-2023-29499
* https://access.redhat.com/security/cve/CVE-2023-29499
* https://iq.sonatype.dev/assets/index.html#/applicationReport/docker-nexus-iq-server-rh/99fca4652293442c885165bdde8aea6f/componentDetails/8cac6e7cbfe74a0c7035/violations

**Test Jobs:**
* https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/main-image/job/iq-server-docker-image-build-test/job/SDEV-840-Swith-To-REHL-9/1/
* https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/redhat-image/job/iq-server-docker-slim-red-hat-build-test/job/SDEV-840-Swith-To-REHL-9/
* https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/slim-image/job/iq-server-docker-slim-image-build-test/job/SDEV-840-Swith-To-REHL-9/