### PR TITLE
Bump base image to version 9.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # hadolint ignore=DL3026
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.175.0-01

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # hadolint ignore=DL3026
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.165.0-01

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # hadolint ignore=DL3026
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 
 # Build parameters
 ARG IQ_SERVER_VERSION=1.175.0-01


### PR DESCRIPTION
Bump base image to version 9.4

https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/main-image/job/iq-server-docker-image-build-test/job/bump_base_rhel_9_4/

https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/redhat-image/job/iq-server-docker-slim-red-hat-build-test/job/bump_base_rhel_9_4/

https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/docker/job/slim-image/job/iq-server-docker-slim-image-build-test/job/bump_base_rhel_9_4/