### PR TITLE
Crypto policies fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,9 @@ RUN rm -rf ${TEMP} \
 && chown -R nexus:nexus ${CONFIG_HOME} \
 && chown -R nexus:nexus ${LOGS_HOME}
 
+# enabling back support for SHA1 signed certificates
+RUN update-crypto-policies --set DEFAULT:SHA1
+
 # This is where we will store persistent data
 VOLUME ${SONATYPE_WORK}
 VOLUME ${LOGS_HOME}

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -111,6 +111,9 @@ RUN usermod -a -G root nexus \
 && bash /uid_template.sh \
 && chmod 0664 /etc/passwd
 
+# enabling back support for SHA1 signed certificates
+RUN update-crypto-policies --set DEFAULT:SHA1
+
 # This is where we will store persistent data
 VOLUME ${SONATYPE_WORK}
 VOLUME ${LOGS_HOME}

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -98,6 +98,9 @@ RUN rm -rf ${TEMP} \
 && chown -R nexus:nexus ${CONFIG_HOME} \
 && chown -R nexus:nexus ${LOGS_HOME}
 
+# enabling back support for SHA1 signed certificates
+RUN update-crypto-policies --set DEFAULT:SHA1
+
 # This is where we will store persistent data
 VOLUME ${SONATYPE_WORK}
 VOLUME ${LOGS_HOME}


### PR DESCRIPTION
Enabling back SHA1 signed certificates support, it was disabled in RHEL9 and breaks postgresql db access on Azure.

After upgrade to 1.176.0 our nexus-iq instance was not able to start and connect to the Azure postgresql server anymore, please see the relevant log snippets below. Apparently it has happened because of the base docker image update.

```
Caused by: org.postgresql.util.PSQLException: SSL error: Certificates do not conform to algorithm constraints
	at org.postgresql.ssl.MakeSSL.convert(MakeSSL.java:45)
	at org.postgresql.core.v3.ConnectionFactoryImpl.enableSSL(ConnectionFactoryImpl.java:625)
	at org.postgresql.core.v3.ConnectionFactoryImpl.tryConnect(ConnectionFactoryImpl.java:195)
	at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:262)
	at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:54)
	at org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:273)
	at org.postgresql.Driver.makeConnection(Driver.java:446)
	at org.postgresql.Driver.connect(Driver.java:298)
	at org.apache.commons.dbcp2.DriverConnectionFactory.createConnection(DriverConnectionFactory.java:52)
	at org.apache.commons.dbcp2.PoolableConnectionFactory.makeObject(PoolableConnectionFactory.java:414)
	at org.apache.commons.dbcp2.BasicDataSource.validateConnectionFactory(BasicDataSource.java:113)
	at org.apache.commons.dbcp2.BasicDataSource.createPoolableConnectionFactory(BasicDataSource.java:632)
	... 14 common frames omitted
Caused by: javax.net.ssl.SSLHandshakeException: Certificates do not conform to algorithm constraints
	at sun.security.ssl.Alert.createSSLException(Alert.java:131)
	at sun.security.ssl.TransportContext.fatal(TransportContext.java:331)
	at sun.security.ssl.TransportContext.fatal(TransportContext.java:274)
	at sun.security.ssl.TransportContext.fatal(TransportContext.java:269)
	at sun.security.ssl.CertificateMessage$T13CertificateConsumer.checkServerCerts(CertificateMessage.java:1356)
	at sun.security.ssl.CertificateMessage$T13CertificateConsumer.onConsumeCertificate(CertificateMessage.java:1231)
	at sun.security.ssl.CertificateMessage$T13CertificateConsumer.consume(CertificateMessage.java:1174)
	at sun.security.ssl.SSLHandshake.consume(SSLHandshake.java:377)
	at sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:444)
	at sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:422)
	at sun.security.ssl.TransportContext.dispatch(TransportContext.java:182)
	at sun.security.ssl.SSLTransport.decode(SSLTransport.java:152)
	at sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1401)
	at sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1309)
	at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:440)
	at org.postgresql.ssl.MakeSSL.convert(MakeSSL.java:43)
	... 25 common frames omitted
Caused by: java.security.cert.CertificateException: Certificates do not conform to algorithm constraints
	at sun.security.ssl.AbstractTrustManagerWrapper.checkAlgorithmConstraints(SSLContextImpl.java:1429)
	at sun.security.ssl.AbstractTrustManagerWrapper.checkAdditionalTrust(SSLContextImpl.java:1354)
	at sun.security.ssl.AbstractTrustManagerWrapper.checkServerTrusted(SSLContextImpl.java:1298)
	at sun.security.ssl.CertificateMessage$T13CertificateConsumer.checkServerCerts(CertificateMessage.java:1340)
	... 36 common frames omitted
Caused by: java.security.cert.CertPathValidatorException: Algorithm constraints check failed on signature algorithm: SHA1withRSA
	at sun.security.provider.certpath.AlgorithmChecker.check(AlgorithmChecker.java:237)
	at sun.security.ssl.AbstractTrustManagerWrapper.checkAlgorithmConstraints(SSLContextImpl.java:1425)
	... 39 common frames omitted
```