### PR TITLE
Add add-opens flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,7 @@ HEALTHCHECK CMD curl --fail --silent --show-error http://localhost:8071/healthch
 # Change to nexus user
 USER nexus
 
-ENV JAVA_OPTS="-Djava.util.prefs.userRoot=${SONATYPE_WORK}/javaprefs"
+ENV JAVA_OPTS="--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/sun.security.rsa=ALL-UNNAMED --add-opens=java.base/sun.security.x509=ALL-UNNAMED --add-opens=java.base/sun.security.util=ALL-UNNAMED --add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp.datatype=ALL-UNNAMED -Djava.util.prefs.userRoot=${SONATYPE_WORK}/javaprefs"
 ENV SONATYPE_INTERNAL_HOST_SYSTEM=Docker
 
 WORKDIR ${IQ_HOME}

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -127,7 +127,7 @@ HEALTHCHECK CMD curl --fail --silent --show-error http://localhost:8071/healthch
 # Change to nexus user
 USER nexus
 
-ENV JAVA_OPTS="-Djava.util.prefs.userRoot=${SONATYPE_WORK}/javaprefs"
+ENV JAVA_OPTS="--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/sun.security.rsa=ALL-UNNAMED --add-opens=java.base/sun.security.x509=ALL-UNNAMED --add-opens=java.base/sun.security.util=ALL-UNNAMED --add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp.datatype=ALL-UNNAMED -Djava.util.prefs.userRoot=${SONATYPE_WORK}/javaprefs"
 ENV SONATYPE_INTERNAL_HOST_SYSTEM=Docker-RedHat
 
 WORKDIR ${IQ_HOME}

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -114,7 +114,7 @@ HEALTHCHECK CMD curl --fail --silent --show-error http://localhost:8071/healthch
 # Change to nexus user
 USER nexus
 
-ENV JAVA_OPTS="-Djava.util.prefs.userRoot=${SONATYPE_WORK}/javaprefs"
+ENV JAVA_OPTS="--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/sun.security.rsa=ALL-UNNAMED --add-opens=java.base/sun.security.x509=ALL-UNNAMED --add-opens=java.base/sun.security.util=ALL-UNNAMED --add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp.datatype=ALL-UNNAMED -Djava.util.prefs.userRoot=${SONATYPE_WORK}/javaprefs"
 ENV SONATYPE_INTERNAL_HOST_SYSTEM=Docker
 
 WORKDIR ${IQ_HOME}


### PR DESCRIPTION
Some libraries use the reflection API to attempt to access non-public fields and methods of java.* APIs. This is no longer possible by default on JDK 17, but you can use the --add-opens option on the command line to enable it for specific tools and libraries. This adds the options to keep those libraries functioning as expected with the new Java 17 runtime.

