### PR TITLE
Bump preflight to 1.9.9

### DIFF
--- a/Jenkinsfile.rh.release
+++ b/Jenkinsfile.rh.release
@@ -42,7 +42,7 @@ node('ubuntu-zion') {
       sh 'docker system prune -a -f'
       sh '''
         wget -q -O preflight \
-          https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.9.2/preflight-linux-amd64
+          https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.9.9/preflight-linux-amd64
         chmod 755 preflight
       '''
     }


### PR DESCRIPTION
Release https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Red%20Hat/job/docker-nexus-iq-red-hat-release/65/console failed with:

```
Error: could not submit to pyxis: could not create test results: status code: 400: body: {"type": "about:blank", "title": "Bad Request", "detail": "Validation error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' version '1.9.2' is not supported. Supported versions are: ['1.10.0', '1.9.7', '1.9.8', '1.9.9']", "status": 400, "trace_id": "0xf6c76f425b27e24ba972b18ed939328"}
2024-09-04 08:19:13 GMT-04:00  2024/09/04 12:19:13 could not submit to pyxis: could not create test results: status code: 400: body: {"type": "about:blank", "title": "Bad Request", "detail": "Validation error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' version '1.9.2' is not supported. Supported versions are: ['1.10.0', '1.9.7', '1.9.8', '1.9.9']", "status": 400, "trace_id": "0xf6c76f425b27e24ba972b18ed939328"}
```