### PR TITLE
Always use the latest preflight version available

### DIFF
--- a/Jenkinsfile.rh.release
+++ b/Jenkinsfile.rh.release
@@ -40,11 +40,15 @@ node('ubuntu-zion') {
       checkout scm
 
       sh 'docker system prune -a -f'
-      sh '''
+      sh """
+        pf_version=`curl -L -H "Accept: application/vnd.github+json" \
+          https://api.github.com/repos/redhat-openshift-ecosystem/openshift-preflight/git/refs/tags \
+          | jq -r '.[-1].ref' | cut -d'/' -f 3` 
+        echo "Donwloading preflight ${pf_version} ..."
         wget -q -O preflight \
-          https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.9.9/preflight-linux-amd64
+          https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/${pf_version}/preflight-linux-amd64
         chmod 755 preflight
-      '''
+      """
     }
     stage('Build') {
       withCredentials([


### PR DESCRIPTION
Publishing fails with:
`"Validation error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' version '1.9.9' is not supported. Supported versions are: ['1.10.0', '1.10.1']"`

To avoid that we can always pull the latest available version.

**Jira**: https://sonatype.atlassian.net/browse/INT-8592