### PR TITLE
Fix alpine image health check - CLM-34331

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -80,7 +80,7 @@ USER root
 # For testing
 # hadolint ignore=DL3018
 RUN apk update \
-&& apk add --no-cache procps-ng gzip unzip tar findutils util-linux less rsync git which
+&& apk add --no-cache procps-ng gzip unzip tar findutils util-linux less rsync git which curl
 
 # Create folders & set permissions
 RUN mkdir -p ${IQ_HOME} \

--- a/alpine-expectations.groovy
+++ b/alpine-expectations.groovy
@@ -28,12 +28,13 @@ def containerExpectations() {
     new Expectation('stderr-log', 'test', '-f /var/log/nexus-iq-server/stderr.log | echo $?', '0'),
     new Expectation('home-directory', 'ls', '-la /opt/sonatype | grep nexus-iq-server | awk \'\$9 !~ /^\\.*$/{print \$1,\$3,\$4,\$9}\'', 'drwxr-sr-x nexus nexus nexus-iq-server'),
     new Expectation('start-script', 'test', '-f /opt/sonatype/nexus-iq-server/start.sh | echo $?', '0'),
-    new Expectation('start-script-has-java-opts', 'grep', '\'JAVA_OPTS\' /opt/sonatype/nexus-iq-server/start.sh | echo $?', '0'), 
-    new Expectation('work-directory', 'ls', '-la / | grep sonatype-work | awk \'\$9 !~ /^\\.*$/{print \$1,\$3,\$4,\$9}\'', 'drwxr-xr-x nexus nexus sonatype-work'), 
-    new Expectation('data-directory', 'test', '-d /sonatype-work/data | echo $?', '0'), 
-    new Expectation('config-directory', 'ls', '-la /etc | grep nexus-iq-server | awk \'\$9 !~ /^\\.*$/{print \$1,\$3,\$4,\$9}\'', 'drwxr-xr-x nexus nexus nexus-iq-server'), 
-    new Expectation('config-file', 'test', '-f /etc/nexus-iq-server | echo $?', '0') 
-  ]     
+    new Expectation('start-script-has-java-opts', 'grep', '\'JAVA_OPTS\' /opt/sonatype/nexus-iq-server/start.sh | echo $?', '0'),
+    new Expectation('work-directory', 'ls', '-la / | grep sonatype-work | awk \'\$9 !~ /^\\.*$/{print \$1,\$3,\$4,\$9}\'', 'drwxr-xr-x nexus nexus sonatype-work'),
+    new Expectation('data-directory', 'test', '-d /sonatype-work/data | echo $?', '0'),
+    new Expectation('config-directory', 'ls', '-la /etc | grep nexus-iq-server | awk \'\$9 !~ /^\\.*$/{print \$1,\$3,\$4,\$9}\'', 'drwxr-xr-x nexus nexus nexus-iq-server'),
+    new Expectation('config-file', 'test', '-f /etc/nexus-iq-server | echo $?', '0'),
+    new Expectation('curl', 'curl --version | echo $?', '0')
+  ]
 }
 
-return this; 
+return this;

--- a/alpine-expectations.groovy
+++ b/alpine-expectations.groovy
@@ -33,7 +33,7 @@ def containerExpectations() {
     new Expectation('data-directory', 'test', '-d /sonatype-work/data | echo $?', '0'),
     new Expectation('config-directory', 'ls', '-la /etc | grep nexus-iq-server | awk \'\$9 !~ /^\\.*$/{print \$1,\$3,\$4,\$9}\'', 'drwxr-xr-x nexus nexus nexus-iq-server'),
     new Expectation('config-file', 'test', '-f /etc/nexus-iq-server | echo $?', '0'),
-    new Expectation('curl', 'curl --version | echo $?', '0')
+    new Expectation('curl', 'curl', '--version | echo $?', '0')
   ]
 }
 


### PR DESCRIPTION
https://sonatype.atlassian.net/browse/CLM-34331

`curl`, while included in the builder image, was not actually being included in the IQ server image, causing the healthcheck (which is implemented with curl) to always fail.