### PR TITLE
BNR-1740: Slim Release

### DIFF
--- a/Jenkinsfile.slim.release
+++ b/Jenkinsfile.slim.release
@@ -72,7 +72,7 @@ dockerizedBuildPipeline(
 )
 
 void updateIQServerVersionAndChecksum(String version, String checksumX86_64, String checksumAarch) {
-  def dockerFile = readFile(file: 'Dockerfile')
+  def dockerFile = readFile(file: 'Dockerfile.slim')
   def metaShortVersionRegex = /(release=")(\d\.\d{1,3}\.\d)(" \\)/
   def versionRegex = /(ARG IQ_SERVER_VERSION=)(\d\.\d{1,3}\.\d\-\d{2})/
   def shaRegexAarch = /(ARG IQ_SERVER_SHA256_AARCH=)([A-Fa-f0-9]{64})/
@@ -128,6 +128,7 @@ void pushImage(String imageName) {
         notary --help
         docker buildx create --use --driver-opt image=${sonatypeDockerRegistryId()}/moby/buildkit
         export OCI_REPO="sonatype/nexus-iq-server"
+        export DOCKERFILE="Dockerfile.slim"
         ./build_and_push_images.sh "${env.VERSION}-slim" "latest-slim"
         """
       }


### PR DESCRIPTION
JIRA: https://sonatype.atlassian.net/browse/BNR-1740

The `build_and_push_images.sh` script defaults to `Dockerfile` unless `DOCKERFILE` is explicitly set, causing the slim image to lag one version behind. Full findings and context are documented in the linked JIRA