### PR TITLE
Fix broken hyperlink in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This environment variable can be adjusted at runtime:
 docker run -d -p 8070:8070 -p 8071:8071 --name nexus-iq-server -e JAVA_OPTS="-Doption=value" sonatype/nexus-iq-server
 ```
 
-Further, you can [customize parts of the default config.yml settings by using Java system properties](https://help.sonatype.com/iqserver/configuring/advanced-server-configuration) defined inside the environment variable.
+Further, you can [customize parts of the default config.yml settings by using Java system properties](https://help.sonatype.com/en/configuring-with-java-system-properties.html) defined inside the environment variable.
 
 Example: To customize the logging level that IQ Server will use:
 


### PR DESCRIPTION
The current URL returns a 404. 

The new URL references the documentation on `Configuring with Java System Properties`.