### PR TITLE
CLM-38304 - make docker build input flexible

### DIFF
--- a/Jenkinsfile.alpine.release
+++ b/Jenkinsfile.alpine.release
@@ -23,7 +23,10 @@ properties([
         run(name: 'releaseBuild',
             filter: 'SUCCESSFUL',
             projectName: 'insight/insight-brain/release',
-            description: 'The latest release of IQ Server to build the docker image')
+            description: 'The latest release of IQ Server to build the docker image'),
+        string(name: 'sourceJob',
+            defaultValue: 'insight/insight-brain/release',
+            description: 'Job path to read artifacts from')
     ])
 ])
 
@@ -36,7 +39,7 @@ dockerizedBuildPipeline(
     prepare: {
       githubStatusUpdate('pending')
       version = getVersionFromBuildName(env.releaseBuild_NAME)
-      checksum = readBuildArtifact('insight/insight-brain/release', env.releaseBuild_NUMBER, "artifacts/nexus-iq-server-${version}-linux_musl-x86_64.tgz.sha256").trim()
+      checksum = readBuildArtifact(params.sourceJob, env.releaseBuild_NUMBER, "artifacts/nexus-iq-server-${version}-linux_musl-x86_64.tgz.sha256").trim()
       updateIQServerVersionAndChecksum(version, checksum)
       commitAndPushChanges(version)
     },

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -23,7 +23,10 @@ properties([
     run(name: 'releaseBuild',
         filter: 'SUCCESSFUL',
         projectName: 'insight/insight-brain/release',
-        description: 'The latest release of IQ Server to build the docker image')
+        description: 'The latest release of IQ Server to build the docker image'),
+    string(name: 'sourceJob',
+        defaultValue: 'insight/insight-brain/release',
+        description: 'Job path to read artifacts from')
   ])
 ])
 
@@ -37,8 +40,8 @@ dockerizedBuildPipeline(
   prepare: {
     githubStatusUpdate('pending')
     version = getVersionFromBuildName(env.releaseBuild_NAME)
-    checksumX86_64 = readBuildArtifact('insight/insight-brain/release', env.releaseBuild_NUMBER, "artifacts/nexus-iq-server-${version}-linux-x86_64.tgz.sha256").trim()
-    checksumAarch = readBuildArtifact('insight/insight-brain/release', env.releaseBuild_NUMBER, "artifacts/nexus-iq-server-${version}-linux-aarch_64.tgz.sha256").trim()
+    checksumX86_64 = readBuildArtifact(params.sourceJob, env.releaseBuild_NUMBER, "artifacts/nexus-iq-server-${version}-linux-x86_64.tgz.sha256").trim()
+    checksumAarch = readBuildArtifact(params.sourceJob, env.releaseBuild_NUMBER, "artifacts/nexus-iq-server-${version}-linux-aarch_64.tgz.sha256").trim()
     updateIQServerVersionAndChecksum(version, checksumX86_64, checksumAarch)
     commitAndPushChanges(version)
   },

--- a/Jenkinsfile.rh.release
+++ b/Jenkinsfile.rh.release
@@ -24,7 +24,10 @@ properties([
     run(name: 'releaseBuild',
     filter: 'SUCCESSFUL',
     projectName: 'insight/insight-brain/release',
-    description: 'The latest release of IQ Server to build the docker image')
+    description: 'The latest release of IQ Server to build the docker image'),
+    string(name: 'sourceJob',
+        defaultValue: 'insight/insight-brain/release',
+        description: 'Job path to read artifacts from')
   ]),
 ])
 
@@ -32,7 +35,7 @@ node('ubuntu-zion') {
   try {
     stage('Preparation') {
       env.IQ_SERVER_VERSION = getVersionFromBuildName(env.releaseBuild_NAME)
-      env.IQ_SERVER_CHECKSUM = readBuildArtifact('insight/insight-brain/release', env.releaseBuild_NUMBER, "artifacts/nexus-iq-server-${env.IQ_SERVER_VERSION}-linux-x86_64.tgz.sha256").trim()
+      env.IQ_SERVER_CHECKSUM = readBuildArtifact(params.sourceJob, env.releaseBuild_NUMBER, "artifacts/nexus-iq-server-${env.IQ_SERVER_VERSION}-linux-x86_64.tgz.sha256").trim()
       env.IQ_RELEASE = env.IQ_SERVER_VERSION.split("-")[0]
       env.PF_VERSION = sh( returnStdout: true, script:
           "curl -s -L -H 'Accept: application/vnd.github+json' https://api.github.com/repos/redhat-openshift-ecosystem/openshift-preflight/git/refs/tags | jq -r '.[].ref' | cut -d'/' -f 3 | sort -V | tail -1"

--- a/Jenkinsfile.slim.release
+++ b/Jenkinsfile.slim.release
@@ -23,7 +23,10 @@ properties([
     run(name: 'releaseBuild',
         filter: 'SUCCESSFUL',
         projectName: 'insight/insight-brain/release',
-        description: 'The latest release of IQ Server to build the docker image')
+        description: 'The latest release of IQ Server to build the docker image'),
+    string(name: 'sourceJob',
+        defaultValue: 'insight/insight-brain/release',
+        description: 'Job path to read artifacts from')
   ])
 ])
 
@@ -37,8 +40,8 @@ dockerizedBuildPipeline(
   prepare: {
     githubStatusUpdate('pending')
     version = getVersionFromBuildName(env.releaseBuild_NAME)
-    checksumX86_64 = readBuildArtifact('insight/insight-brain/release', env.releaseBuild_NUMBER, "artifacts/nexus-iq-server-${version}-linux-x86_64.tgz.sha256").trim()
-    checksumAarch = readBuildArtifact('insight/insight-brain/release', env.releaseBuild_NUMBER, "artifacts/nexus-iq-server-${version}-linux-aarch_64.tgz.sha256").trim()
+    checksumX86_64 = readBuildArtifact(params.sourceJob, env.releaseBuild_NUMBER, "artifacts/nexus-iq-server-${version}-linux-x86_64.tgz.sha256").trim()
+    checksumAarch = readBuildArtifact(params.sourceJob, env.releaseBuild_NUMBER, "artifacts/nexus-iq-server-${version}-linux-aarch_64.tgz.sha256").trim()
     updateIQServerVersionAndChecksum(version, checksumX86_64, checksumAarch)
     commitAndPushChanges(version)
   },


### PR DESCRIPTION
JIRA: https://sonatype.atlassian.net/browse/CLM-38304

**Description**
Add sourceJob parameter to Docker release Jenkinsfiles

Adds a sourceJob parameter to all 4 Docker release Jenkinsfiles, allowing the artifact source job to be configured instead of being hardcoded to insight/insight-brain/release.

**Why?**

This enables insight/insight-brain/aggregate-release to trigger these Docker jobs and have them read artifacts from the aggregate-release build instead of the standalone release job.

**Backward Compatible**

The parameter defaults to insight/insight-brain/release, so existing pipelines (including Jenkinsfile.releaseIQServer) continue to work unchanged.
