### PR TITLE
Update UBI base image to 9.7 to fix GnuPG vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # hadolint ignore=DL3026
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5 AS builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7 AS builder
 ARG TEMP="/tmp/work"
 # Build parameters
 ARG IQ_SERVER_VERSION=1.199.0-01
@@ -52,7 +52,7 @@ RUN sha256sum -c nexus-iq-server.tar.gz.sha256 \
     && mv nexus-iq-server-${IQ_SERVER_VERSION}-linux-* nexus-iq-server
 
 # hadolint ignore=DL3026
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 
 ARG IQ_SERVER_VERSION=1.199.0-01
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -15,7 +15,7 @@
 #
 
 # hadolint ignore=DL3026
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5 AS builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7 AS builder
 ARG TEMP="/tmp/work"
 # Build parameters
 ARG IQ_SERVER_VERSION=1.185.0-01
@@ -44,7 +44,7 @@ RUN sha256sum -c nexus-iq-server.tar.gz.sha256 \
     && mv nexus-iq-server-${IQ_SERVER_VERSION}-linux-* nexus-iq-server
 
 # hadolint ignore=DL3026
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 
 ARG IQ_SERVER_VERSION=1.185.0-01
 ARG IQ_RELEASE

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -15,7 +15,7 @@
 #
 
 # hadolint ignore=DL3026
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5 AS builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7 AS builder
 ARG TEMP="/tmp/work"
 # Build parameters
 ARG IQ_SERVER_VERSION=1.199.0-01
@@ -52,7 +52,7 @@ RUN sha256sum -c nexus-iq-server.tar.gz.sha256 \
     && mv nexus-iq-server-${IQ_SERVER_VERSION}-linux-* nexus-iq-server
 
 # hadolint ignore=DL3026
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 
 ARG IQ_SERVER_VERSION=1.199.0-01
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"


### PR DESCRIPTION
Updated Red Hat UBI minimal base image from 9.5 to 9.7 to address CVE in GnuPG's armor_filter function that could lead to out-of-bounds write, information disclosure, and potential arbitrary code execution.

Files updated:
- Dockerfile (Standard Docker Image)
- Dockerfile.slim (Slim Docker Image)
- Dockerfile.rh (RedHat Docker Image)

Both builder and runtime stages updated to use ubi-minimal:9.7.