### PR TITLE
CLM-39201: Remove shell from IQ Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,9 @@ RUN apk add --no-cache maven-3.9 openjdk-17-jre gcc \
 
 # Copy and compile the launcher with build-time paths
 COPY launcher.c /tmp/launcher.c
-RUN gcc -DIQ_HOME=${IQ_HOME} \
-         -DCONFIG_HOME=${CONFIG_HOME} \
-         -DLOGS_HOME=${LOGS_HOME} \
+RUN gcc -DIQ_HOME=\"${IQ_HOME}\" \
+         -DCONFIG_HOME=\"${CONFIG_HOME}\" \
+         -DLOGS_HOME=\"${LOGS_HOME}\" \
          -o /runtime-deps/bin/launcher /tmp/launcher.c
 
 # Create user/group entries in runtime root.

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN apk add --no-cache maven-3.9 openjdk-17-jre gcc \
         --keys-dir /etc/apk/keys \
         --repositories-file /etc/apk/repositories \
         tini-static \
-        git
+        git-bootstrap
 
 # Copy and compile the launcher with build-time paths
 COPY launcher.c /tmp/launcher.c

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,9 +53,10 @@ RUN gcc -DIQ_HOME=\"${IQ_HOME}\" \
 
 # Create user/group entries in runtime root.
 # Include root user (UID 0) for system compatibility, plus nexus user.
+# Use nologin as shell since the runtime image has no shell anyway.
 RUN mkdir -p /runtime-deps/etc \
-    && echo "root:x:0:0:root:/root:/bin/sh" > /runtime-deps/etc/passwd \
-    && echo "nexus:x:${UID}:${GID}:Nexus IQ user:${IQ_HOME}:/bin/false" >> /runtime-deps/etc/passwd \
+    && echo "root:x:0:0:root:/root:/usr/sbin/nologin" > /runtime-deps/etc/passwd \
+    && echo "nexus:x:${UID}:${GID}:Nexus IQ user:${IQ_HOME}:/usr/sbin/nologin" >> /runtime-deps/etc/passwd \
     && echo "root:x:0:" > /runtime-deps/etc/group \
     && echo "nexus:x:${GID}:" >> /runtime-deps/etc/group
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,18 +24,21 @@ ARG IQ_SERVER_VERSION=1.202.0-01
 
 # Install Maven + JRE (for artifact download) and runtime deps into isolated root.
 # Runtime deps rationale:
-# - busybox: provides /bin/sh (runtime image is distroless, needs shell for start.sh)
-# - tini-static: init daemon for zombie process reaping
+# - tini-static: init daemon for zombie process reaping and signal forwarding
 # - git: required for IQ Server SCM integrations
+# - gcc: compile the launcher.c (build-time only, not copied to runtime)
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 # hadolint ignore=DL3018
-RUN apk add --no-cache maven-3.9 openjdk-17-jre \
+RUN apk add --no-cache maven-3.9 openjdk-17-jre gcc \
     && apk add --no-cache --initdb --root /runtime-deps \
         --keys-dir /etc/apk/keys \
         --repositories-file /etc/apk/repositories \
-        busybox \
         tini-static \
         git
+
+# Copy and compile the launcher
+COPY launcher.c /tmp/launcher.c
+RUN gcc -o /runtime-deps/bin/launcher /tmp/launcher.c
 
 # Download the server jar and JVM options file as individual Maven artifacts.
 # Uses BuildKit secret mount for settings.xml so credentials never appear in any layer.
@@ -115,12 +118,6 @@ RUN chmod 0644 ${CONFIG_HOME}/config.yml
 # Copy server assemblies
 COPY --chown=65532:65532 --from=packages /tmp/download/nexus-iq-server ${IQ_HOME}
 
-# Create start script
-RUN echo "trap 'kill -TERM \`cut -f1 -d@ ${SONATYPE_WORK}/lock\`; timeout ${TIMEOUT} tail --pid=\`cut -f1 -d@ ${SONATYPE_WORK}/lock\` -f /dev/null' SIGTERM" > ${IQ_HOME}/start.sh \
-&& echo "java @${IQ_HOME}/jvm.options \$JAVA_OPTS -jar ${IQ_HOME}/nexus-iq-server.jar server ${CONFIG_HOME}/config.yml 2> ${LOGS_HOME}/stderr.log & " >> ${IQ_HOME}/start.sh \
-&& echo "wait" >> ${IQ_HOME}/start.sh \
-&& chmod 0755 ${IQ_HOME}/start.sh
-
 WORKDIR ${IQ_HOME}
 
 # This is where we will store persistent data
@@ -142,6 +139,6 @@ ENV SONATYPE_INTERNAL_HOST_SYSTEM=Docker
 
 WORKDIR ${IQ_HOME}
 
-# tini as init daemon for zombie process reaping
+# tini as init daemon for zombie process reaping and signal forwarding
 ENTRYPOINT ["/sbin/tini-static", "--"]
-CMD [ "sh", "./start.sh" ]
+CMD ["/bin/launcher"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,9 @@ RUN apk add --no-cache maven-3.9 openjdk-17-jre gcc \
 
 # Copy and compile the launcher with build-time paths
 COPY launcher.c /tmp/launcher.c
-RUN gcc -DIQ_HOME=\"${IQ_HOME}\" \
-         -DCONFIG_HOME=\"${CONFIG_HOME}\" \
-         -DLOGS_HOME=\"${LOGS_HOME}\" \
+RUN gcc -DIQ_HOME=${IQ_HOME} \
+         -DCONFIG_HOME=${CONFIG_HOME} \
+         -DLOGS_HOME=${LOGS_HOME} \
          -o /runtime-deps/bin/launcher /tmp/launcher.c
 
 # Create user/group entries in runtime root.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@
 # hadolint ignore=DL3006,DL3026
 FROM sonatype.repo.sonatype.app/docker-all/chainguard/wolfi-base AS packages
 
-ARG IQ_SERVER_VERSION=1.202.1-01
+ARG IQ_SERVER_VERSION=1.203.0-SNAPSHOT
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
 ARG SONATYPE_WORK="/sonatype-work"
 ARG CONFIG_HOME="/etc/nexus-iq-server"
@@ -99,7 +99,7 @@ RUN chown ${UID}:${GID} /runtime-deps/etc/nexus-iq-server/config.yml \
 # hadolint ignore=DL3026
 FROM sonatype.repo.sonatype.app/docker-all/sonatype-infosec/jre:openjdk-17
 
-ARG IQ_SERVER_VERSION=1.202.1-01
+ARG IQ_SERVER_VERSION=1.203.0-SNAPSHOT
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
 ARG SONATYPE_WORK="/sonatype-work"
 ARG CONFIG_HOME="/etc/nexus-iq-server"
@@ -110,7 +110,7 @@ LABEL name="Nexus IQ Server image" \
   maintainer="Sonatype <support@sonatype.com>" \
   vendor=Sonatype \
   version="${IQ_SERVER_VERSION}" \
-  release="1.202.1" \
+  release="1.203.0" \
   url="https://www.sonatype.com" \
   summary="The Nexus IQ Server" \
   description="Nexus IQ Server is a policy engine powered by precise intelligence on open source components. \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,17 @@
 # Uses a Wolfi base with apk to:
 # 1. Install runtime dependencies (git, tini) into an isolated root
 # 2. Download the IQ Server artifacts from Maven (needs Maven for auth + SNAPSHOT resolution)
+# 3. Create users, groups, and directory structure for the runtime image
 # hadolint ignore=DL3006,DL3026
 FROM sonatype.repo.sonatype.app/docker-all/chainguard/wolfi-base AS packages
+
 ARG IQ_SERVER_VERSION=1.203.0-SNAPSHOT
+ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
+ARG SONATYPE_WORK="/sonatype-work"
+ARG CONFIG_HOME="/etc/nexus-iq-server"
+ARG LOGS_HOME="/var/log/nexus-iq-server"
+ARG GID=1000
+ARG UID=1000
 
 # Install Maven + JRE (for artifact download) and runtime deps into isolated root.
 # Runtime deps rationale:
@@ -36,9 +44,30 @@ RUN apk add --no-cache maven-3.9 openjdk-17-jre gcc \
         tini-static \
         git
 
-# Copy and compile the launcher
+# Copy and compile the launcher with build-time paths
 COPY launcher.c /tmp/launcher.c
-RUN gcc -o /runtime-deps/bin/launcher /tmp/launcher.c
+RUN gcc -DIQ_HOME=\"${IQ_HOME}\" \
+         -DCONFIG_HOME=\"${CONFIG_HOME}\" \
+         -DLOGS_HOME=\"${LOGS_HOME}\" \
+         -o /runtime-deps/bin/launcher /tmp/launcher.c
+
+# Create user/group entries in runtime root.
+# Include root user (UID 0) for system compatibility, plus nexus user.
+RUN mkdir -p /runtime-deps/etc \
+    && echo "root:x:0:0:root:/root:/bin/sh" > /runtime-deps/etc/passwd \
+    && echo "nexus:x:${UID}:${GID}:Nexus IQ user:${IQ_HOME}:/bin/false" >> /runtime-deps/etc/passwd \
+    && echo "root:x:0:" > /runtime-deps/etc/group \
+    && echo "nexus:x:${GID}:" >> /runtime-deps/etc/group
+
+# Create directory structure with proper ownership in runtime root
+RUN mkdir -p /runtime-deps/opt/sonatype/nexus-iq-server \
+    && mkdir -p /runtime-deps/sonatype-work \
+    && mkdir -p /runtime-deps/etc/nexus-iq-server \
+    && mkdir -p /runtime-deps/var/log/nexus-iq-server \
+    && chown -R ${UID}:${GID} /runtime-deps/opt/sonatype/nexus-iq-server \
+    && chown -R ${UID}:${GID} /runtime-deps/sonatype-work \
+    && chown -R ${UID}:${GID} /runtime-deps/etc/nexus-iq-server \
+    && chown -R ${UID}:${GID} /runtime-deps/var/log/nexus-iq-server
 
 # Download the server jar and JVM options file as individual Maven artifacts.
 # Uses BuildKit secret mount for settings.xml so credentials never appear in any layer.
@@ -55,8 +84,17 @@ RUN --mount=type=secret,id=maven-settings,target=/root/.m2/settings.xml \
     && mv insight-brain-service-*-server.jar nexus-iq-server.jar \
     && mv nexus-iq-server-*-jvm.options jvm.options
 
+# Copy downloaded server files into runtime root with correct ownership
+RUN cp -r /tmp/download/nexus-iq-server/* /runtime-deps/opt/sonatype/nexus-iq-server/ \
+    && chown -R ${UID}:${GID} /runtime-deps/opt/sonatype/nexus-iq-server
+
+# Copy config.yml into runtime root with correct permissions
+COPY config.yml /runtime-deps/etc/nexus-iq-server/config.yml
+RUN chown ${UID}:${GID} /runtime-deps/etc/nexus-iq-server/config.yml \
+    && chmod 0644 /runtime-deps/etc/nexus-iq-server/config.yml
+
 # === Runtime stage ===
-# Uses the minimal variant (no package manager)
+# Uses the minimal variant (no package manager, no shell)
 # hadolint ignore=DL3026
 FROM sonatype.repo.sonatype.app/docker-all/sonatype-infosec/jre:openjdk-17
 
@@ -65,8 +103,6 @@ ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
 ARG SONATYPE_WORK="/sonatype-work"
 ARG CONFIG_HOME="/etc/nexus-iq-server"
 ARG LOGS_HOME="/var/log/nexus-iq-server"
-ARG GID=1000
-ARG UID=1000
 ARG TIMEOUT=600
 
 LABEL name="Nexus IQ Server image" \
@@ -89,36 +125,16 @@ LABEL name="Nexus IQ Server image" \
   io.openshift.expose-services="8071:8071" \
   io.openshift.tags="Sonatype,Nexus,IQ Server"
 
-# The infosec runtime image defaults to a non-root user; switch to root for setup
-USER root
-
-# Copy runtime dependencies (git, tini) and all their transitive deps from the
-# packages stage
+# Copy the entire runtime filesystem from packages stage:
+# - /etc/passwd and /etc/group (nexus user/group)
+# - /bin/launcher
+# - /sbin/tini-static
+# - /opt/sonatype/nexus-iq-server (with server jar and jvm.options)
+# - /etc/nexus-iq-server/config.yml
+# - /var/log/nexus-iq-server directory
+# - /sonatype-work directory
+# - git and its dependencies
 COPY --from=packages /runtime-deps/ /
-
-# Add group and user
-RUN addgroup -g ${GID} nexus \
-    && adduser -u ${UID} -h ${IQ_HOME} -g "Nexus IQ user" -G nexus -s /bin/false -D nexus
-
-# Create folders & set permissions
-RUN mkdir -p ${IQ_HOME} \
-&& mkdir -p ${SONATYPE_WORK} \
-&& mkdir -p ${CONFIG_HOME} \
-&& mkdir -p ${LOGS_HOME} \
-&& chmod 0755 "/opt/sonatype" ${IQ_HOME} \
-&& chmod 0755 ${CONFIG_HOME} \
-&& chmod 0755 ${LOGS_HOME} \
-&& chown -R nexus:nexus ${IQ_HOME} \
-&& chown -R nexus:nexus ${SONATYPE_WORK} \
-&& chown -R nexus:nexus ${CONFIG_HOME} \
-&& chown -R nexus:nexus ${LOGS_HOME}
-
-# Copy config.yml (already configured for Docker with absolute paths)
-COPY config.yml ${CONFIG_HOME}/config.yml
-RUN chmod 0644 ${CONFIG_HOME}/config.yml
-
-# Copy server assemblies
-COPY --chown=nexus:nexus --from=packages /tmp/download/nexus-iq-server ${IQ_HOME}
 
 WORKDIR ${IQ_HOME}
 
@@ -131,15 +147,13 @@ EXPOSE 8070
 EXPOSE 8071
 
 # Wire up health check using localcheck (built into infosec base images)
-HEALTHCHECK CMD localcheck --port 8071 || exit 1
+HEALTHCHECK CMD ["localcheck", "--port", "8071"]
 
-# Change to nexus user
+# Change to nexus user (created in packages stage)
 USER nexus
 
 ENV JAVA_OPTS=" -Djava.util.prefs.userRoot=${SONATYPE_WORK}/javaprefs "
 ENV SONATYPE_INTERNAL_HOST_SYSTEM=Docker
-
-WORKDIR ${IQ_HOME}
 
 # tini as init daemon for zombie process reaping and signal forwarding
 ENTRYPOINT ["/sbin/tini-static", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@
 # hadolint ignore=DL3006,DL3026
 FROM sonatype.repo.sonatype.app/docker-all/chainguard/wolfi-base AS packages
 
-ARG IQ_SERVER_VERSION=1.203.0-SNAPSHOT
+ARG IQ_SERVER_VERSION=1.202.1-01
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
 ARG SONATYPE_WORK="/sonatype-work"
 ARG CONFIG_HOME="/etc/nexus-iq-server"
@@ -99,7 +99,7 @@ RUN chown ${UID}:${GID} /runtime-deps/etc/nexus-iq-server/config.yml \
 # hadolint ignore=DL3026
 FROM sonatype.repo.sonatype.app/docker-all/sonatype-infosec/jre:openjdk-17
 
-ARG IQ_SERVER_VERSION=1.203.0-SNAPSHOT
+ARG IQ_SERVER_VERSION=1.202.1-01
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
 ARG SONATYPE_WORK="/sonatype-work"
 ARG CONFIG_HOME="/etc/nexus-iq-server"
@@ -110,7 +110,7 @@ LABEL name="Nexus IQ Server image" \
   maintainer="Sonatype <support@sonatype.com>" \
   vendor=Sonatype \
   version="${IQ_SERVER_VERSION}" \
-  release="1.203.0" \
+  release="1.202.1" \
   url="https://www.sonatype.com" \
   summary="The Nexus IQ Server" \
   description="Nexus IQ Server is a policy engine powered by precise intelligence on open source components. \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,8 @@ dockerizedBuildPipeline(
   deployCondition: { return true }, // always run the deploy stage
   prepare: {
     githubStatusUpdate('pending')
+    // Pull alpine image for Container Security OS package scanning
+    sh 'docker pull alpine:latest'
   },
   lint: {
     hadolint(['./Dockerfile'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,6 +70,7 @@ dockerizedBuildPipeline(
     // Push the cached multi-platform build to the registry
     withSonatypeDockerRegistry() {
       configFileProvider([configFile(fileId: 'private-settings.xml', targetLocation: "${env.WORKSPACE}/.m2/settings.xml")]) {
+        sh "docker buildx create --driver-opt=\"image=${sonatypeDockerRegistryId()}/moby/buildkit\" --use"
         sh "docker buildx build --platform linux/amd64,linux/arm64 " +
             "--cache-from type=local,src=${env.WORKSPACE}/.buildx-cache " +
             "--secret id=maven-settings,src=${env.WORKSPACE}/.m2/settings.xml " +

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,10 +41,12 @@ dockerizedBuildPipeline(
       sh 'echo $JENKINS_DOCKER_PASSWORD | docker login -u $JENKINS_DOCKER_USERNAME --password-stdin sonatype.repo.sonatype.app'
       configFileProvider([configFile(fileId: 'private-settings.xml', targetLocation: "${env.WORKSPACE}/.m2/settings.xml")]) {
         sh "docker buildx create --driver-opt=\"image=${sonatypeDockerRegistryId()}/moby/buildkit\" --use"
-        sh "docker buildx build --platform linux/amd64,linux/arm64 " +
+        // Build single platform for testing, cache for multi-platform deploy
+        sh "docker buildx build --platform linux/amd64 " +
             "--cache-to type=local,dest=${env.WORKSPACE}/.buildx-cache " +
-            "--output type=docker,name=${productionImage} " +
-            "--secret id=maven-settings,src=${env.WORKSPACE}/.m2/settings.xml ."
+            "--load " +
+            "--secret id=maven-settings,src=${env.WORKSPACE}/.m2/settings.xml " +
+            "--tag ${productionImage} ."
       }
     }
     def containerName = 'iq-server-test'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,11 @@ dockerizedBuildPipeline(
     withSonatypeDockerRegistry() {
       sh 'echo $JENKINS_DOCKER_PASSWORD | docker login -u $JENKINS_DOCKER_USERNAME --password-stdin sonatype.repo.sonatype.app'
       configFileProvider([configFile(fileId: 'private-settings.xml', targetLocation: "${env.WORKSPACE}/.m2/settings.xml")]) {
-        sh "DOCKER_BUILDKIT=1 docker build --secret id=maven-settings,src=${env.WORKSPACE}/.m2/settings.xml --tag ${productionImage} ."
+        sh "docker buildx create --driver-opt=\"image=${sonatypeDockerRegistryId()}/moby/buildkit\" --use"
+        sh "docker buildx build --platform linux/amd64,linux/arm64 " +
+            "--cache-to type=local,dest=${env.WORKSPACE}/.buildx-cache " +
+            "--output type=docker,name=${productionImage} " +
+            "--secret id=maven-settings,src=${env.WORKSPACE}/.m2/settings.xml ."
       }
     }
     def containerName = 'iq-server-test'
@@ -59,13 +63,14 @@ dockerizedBuildPipeline(
     }
   },
   deploy: {
-    // Run a multi-platform buildx build to verify cross-platform compatibility
+    // Push the cached multi-platform build to the registry
     withSonatypeDockerRegistry() {
       configFileProvider([configFile(fileId: 'private-settings.xml', targetLocation: "${env.WORKSPACE}/.m2/settings.xml")]) {
-        sh "docker buildx create --driver-opt=\"image=${sonatypeDockerRegistryId()}/moby/buildkit\" --use"
         sh "docker buildx build --platform linux/amd64,linux/arm64 " +
+            "--cache-from type=local,src=${env.WORKSPACE}/.buildx-cache " +
             "--secret id=maven-settings,src=${env.WORKSPACE}/.m2/settings.xml " +
-            "--tag ${sonatypeDockerRegistryId()}/${imageName}:${env.BUILD_NUMBER} ."
+            "--tag ${sonatypeDockerRegistryId()}/${imageName}:${env.BUILD_NUMBER} " +
+            "--push ."
       }
     }
   },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,11 +81,12 @@ dockerizedBuildPipeline(
   },
   vulnerabilityScan: {
     def theStage = env.BRANCH_NAME == deployBranch ? 'build' : 'develop'
-    nexusPolicyEvaluation(
-      iqApplication: 'docker-nexus-iq-server',
-      iqScanPatterns: [[scanPattern: "container:${productionImage}"]],
-      iqStage: theStage,
-      containerScannerMode: 'sonatype')
+    withEnv(['NEXUS_CONTAINER_SCANNER_MODE=sonatype']) {
+      nexusPolicyEvaluation(
+        iqApplication: 'docker-nexus-iq-server',
+        iqScanPatterns: [[scanPattern: "container:${productionImage}"]],
+        iqStage: theStage)
+    }
   },
   onUnstable: {
     if (env.BRANCH_NAME == deployBranch) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,12 +81,10 @@ dockerizedBuildPipeline(
   },
   vulnerabilityScan: {
     def theStage = env.BRANCH_NAME == deployBranch ? 'build' : 'develop'
-    withEnv(['NEXUS_CONTAINER_SCANNER_MODE=sonatype']) {
-      nexusPolicyEvaluation(
-        iqApplication: 'docker-nexus-iq-server',
-        iqScanPatterns: [[scanPattern: "container:${productionImage}"]],
-        iqStage: theStage)
-    }
+    nexusPolicyEvaluation(
+      iqApplication: 'docker-nexus-iq-server',
+      iqScanPatterns: [[scanPattern: "container:${productionImage}"]],
+      iqStage: theStage)
   },
   onUnstable: {
     if (env.BRANCH_NAME == deployBranch) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ dockerizedBuildPipeline(
     }
     def containerName = 'iq-server-test'
     try {
-      sh "docker run -d --name ${containerName} ${productionImage}"
+      sh "docker run -d --name ${containerName} -e JAVA_OPTS='-Dtest.java.opts=works' ${productionImage}"
       // localcheck hits /ping (always 200 when admin port is ready).
       // Extra sleep lets the server finish writing log files before expectations run.
       sh """for i in \$(seq 1 60); do

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,8 @@ dockerizedBuildPipeline(
     nexusPolicyEvaluation(
       iqApplication: 'docker-nexus-iq-server',
       iqScanPatterns: [[scanPattern: "container:${productionImage}"]],
-      iqStage: theStage)
+      iqStage: theStage,
+      containerScannerMode: 'sonatype')
   },
   onUnstable: {
     if (env.BRANCH_NAME == deployBranch) {

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -60,7 +60,7 @@ dockerizedBuildPipeline(
     }
     def containerName = 'iq-server-test'
     try {
-      sh "docker run -d --name ${containerName} ${productionImage}"
+      sh "docker run -d --name ${containerName} -e JAVA_OPTS='-Dtest.java.opts=works' ${productionImage}"
       // localcheck hits /ping (always 200 when admin port is ready).
       // Extra sleep lets the server finish writing log files before expectations run.
       sh """for i in \$(seq 1 60); do

--- a/README.md
+++ b/README.md
@@ -40,8 +40,42 @@ The Docker image has been migrated from Red Hat UBI 9 Minimal to Sonatype's info
 - **User:** The container now runs as `nonroot` (UID 65532) instead of `nexus` (UID 1000)
 - **Init daemon:** `tini` is used as the init process for proper zombie process reaping
 - **Health check:** Uses `localcheck` (built into base image) instead of `curl`
-- **No shell:** The runtime image no longer contains a shell (`/bin/sh`). Use `docker cp` or ephemeral debug containers for troubleshooting.
+- **No shell or standard utilities:** The runtime image is distroless — there is no `/bin/sh`, `bash`, `cat`, `ls`, `grep`, `ps`, etc. See [Debugging Without a Shell](#debugging-without-a-shell) below for the practical implications.
+- **JVM stderr location:** Because the launcher runs the JVM directly (no wrapper shell), it redirects `stderr` to `/var/log/nexus-iq-server/stderr.log` inside the container so that errors are still captured. `docker logs` will not show `stderr`; only the Dropwizard/Logback `stdout` appender does.
 - **Removed variants:** The `-slim` and `-alpine` image tags are no longer published
+
+#### Debugging Without a Shell
+
+`docker exec -it <container> bash` (or `sh`) no longer works. Use these alternatives:
+
+- **Read a file from the container:**
+  ```
+  docker cp nexus-iq-server:/var/log/nexus-iq-server/clm-server.log ./clm-server.log
+  ```
+  To stream a file or directory as a tar archive to stdout, use `-` as the destination:
+  ```
+  docker cp nexus-iq-server:/etc/nexus-iq-server/config.yml - | tar -xO
+  ```
+- **List running processes:**
+  ```
+  docker top nexus-iq-server
+  ```
+- **Retrieve JVM stderr:**
+  ```
+  docker cp nexus-iq-server:/var/log/nexus-iq-server/stderr.log -
+  ```
+  (or mount `/var/log/nexus-iq-server` as a volume so the file is accessible from the host)
+- **Run arbitrary commands against the running container's filesystem, processes, and network:** attach an ephemeral debug container that shares namespaces with the target. For example:
+  ```
+  docker run --rm -it \
+    --pid=container:nexus-iq-server \
+    --network=container:nexus-iq-server \
+    --volumes-from nexus-iq-server \
+    alpine sh
+  ```
+  This provides full shell access without modifying the hardened image.
+
+Scripts and automation that previously used `docker exec <container> sh -c '...'` against this image must be rewritten to use one of the approaches above.
 
 If you use this image with persistent data volumes, you will need to update file ownership for each volume:
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ The Docker image has been migrated from Red Hat UBI 9 Minimal to Sonatype's info
 - **Base image:** Wolfi-based distroless image (`sonatype-infosec/jdk:openjdk-17`) instead of UBI 9 Minimal
 - **User:** The container now runs as `nonroot` (UID 65532) instead of `nexus` (UID 1000)
 - **Init daemon:** `tini` is used as the init process for proper zombie process reaping
-- **Health check:** Uses a precompiled Java class instead of `curl`
+- **Health check:** Uses `localcheck` (built into base image) instead of `curl`
+- **No shell:** The runtime image no longer contains a shell (`/bin/sh`). Use `docker cp` or ephemeral debug containers for troubleshooting.
 - **Removed variants:** The `-slim` and `-alpine` image tags are no longer published
 
 If you use this image with persistent data volumes, you will need to update file ownership for each volume:

--- a/expectations.groovy
+++ b/expectations.groovy
@@ -17,27 +17,33 @@
 import com.sonatype.jenkins.shared.Expectation
 
 def containerExpectations(String containerName = 'iq-server-test') {
-  def c = containerName
+  // Get container PID for host-side /proc inspection
+  def pid = sh(script: "docker inspect --format '{{.State.Pid}}' ${containerName}", returnStdout: true).trim()
+
   return [
-    new Expectation('nonroot-group', 'docker', "exec ${c} grep '^nonroot:' /etc/group", 'nonroot:x:65532:'),
-    new Expectation('nonroot-user', 'docker', "exec ${c} grep '^nonroot:' /etc/passwd", 'nonroot:x:65532:65532:nonroot:/home/nonroot:/sbin/nologin'),
-    new Expectation('iq-process', 'docker', "exec ${c} sh -c 'ps -e -o command,user | grep -q ^/usr/bin/java.*nonroot\$ | echo \$?'", '0'),
-    new Expectation('application-port', 'docker', "exec ${c} sh -c 'localcheck --port 8070 --path / && echo OK'", 'OK'),
-    new Expectation('admin-port', 'docker', "exec ${c} sh -c 'localcheck --port 8071 && echo OK'", 'OK'),
-    new Expectation('log-directory', 'docker', "exec ${c} ls -ld /var/log/nexus-iq-server", 'drwxr-xr-x.*nonroot.*nonroot.*nexus-iq-server'),
-    new Expectation('clm-server-log', 'docker', "exec ${c} sh -c 'test -f /var/log/nexus-iq-server/clm-server.log && echo OK'", 'OK'),
-    new Expectation('audit-log', 'docker', "exec ${c} sh -c 'test -f /var/log/nexus-iq-server/audit.log && echo OK'", 'OK'),
-    new Expectation('request-log', 'docker', "exec ${c} sh -c 'test -f /var/log/nexus-iq-server/request.log && echo OK'", 'OK'),
-    new Expectation('stderr-log', 'docker', "exec ${c} sh -c 'test -f /var/log/nexus-iq-server/stderr.log && echo OK'", 'OK'),
-    new Expectation('home-directory', 'docker', "exec ${c} ls -ld /opt/sonatype/nexus-iq-server", 'drwxr-xr-x.*nonroot.*nonroot.*nexus-iq-server'),
-    new Expectation('start-script', 'docker', "exec ${c} sh -c 'test -f /opt/sonatype/nexus-iq-server/start.sh && echo OK'", 'OK'),
-    new Expectation('start-script-has-java-opts', 'docker', "exec ${c} grep JAVA_OPTS /opt/sonatype/nexus-iq-server/start.sh", 'JAVA_OPTS'),
-    new Expectation('work-directory', 'docker', "exec ${c} ls -ld /sonatype-work", 'drwxr-xr-x.*nonroot.*nonroot.*sonatype-work'),
-    new Expectation('data-directory', 'docker', "exec ${c} sh -c 'test -d /sonatype-work/data && echo OK'", 'OK'),
-    new Expectation('config-directory', 'docker', "exec ${c} ls -ld /etc/nexus-iq-server", 'drwxr-xr-x.*nonroot.*nonroot.*nexus-iq-server'),
-    new Expectation('config-file', 'docker', "exec ${c} sh -c 'test -f /etc/nexus-iq-server/config.yml && echo OK'", 'OK'),
-    new Expectation('tini', 'docker', "exec ${c} sh -c 'test -x /sbin/tini-static && echo OK'", 'OK'),
-    new Expectation('localcheck', 'docker', "exec ${c} sh -c 'which localcheck && echo OK'", 'OK')
+    // === Process verification (via host /proc) ===
+    new Expectation('java-process', 'sh', "-c 'cat /proc/${pid}/comm'", 'java'),
+    new Expectation('java-opts-applied', 'sh', "-c 'cat /proc/${pid}/cmdline | tr \"\\\\0\" \" \"'", '-Dtest.java.opts=works'),
+
+    // === Port checks (localcheck is built into base image) ===
+    new Expectation('application-port', 'docker', "exec ${containerName} localcheck --port 8070 --path /", ''),
+    new Expectation('admin-port', 'docker', "exec ${containerName} localcheck --port 8071", ''),
+
+    // === File existence (via docker cp | tar -t) ===
+    new Expectation('launcher-exists', 'sh', "-c 'docker cp ${containerName}:/bin/launcher - | tar -t | grep launcher'", 'launcher'),
+    new Expectation('tini-exists', 'sh', "-c 'docker cp ${containerName}:/sbin/tini-static - | tar -t | grep tini-static'", 'tini-static'),
+    new Expectation('config-file', 'sh', "-c 'docker cp ${containerName}:/etc/nexus-iq-server/config.yml - | tar -t | grep config.yml'", 'config.yml'),
+    new Expectation('iq-home', 'sh', "-c 'docker cp ${containerName}:/opt/sonatype/nexus-iq-server/nexus-iq-server.jar - | tar -t | grep nexus-iq-server.jar'", 'nexus-iq-server.jar'),
+
+    // === Log files ===
+    new Expectation('stderr-log', 'sh', "-c 'docker cp ${containerName}:/var/log/nexus-iq-server/stderr.log - | tar -t | grep stderr.log'", 'stderr.log'),
+    new Expectation('clm-server-log', 'sh', "-c 'docker cp ${containerName}:/var/log/nexus-iq-server/clm-server.log - | tar -t | grep clm-server.log'", 'clm-server.log'),
+    new Expectation('audit-log', 'sh', "-c 'docker cp ${containerName}:/var/log/nexus-iq-server/audit.log - | tar -t | grep audit.log'", 'audit.log'),
+    new Expectation('request-log', 'sh', "-c 'docker cp ${containerName}:/var/log/nexus-iq-server/request.log - | tar -t | grep request.log'", 'request.log'),
+
+    // === User/group verification (via docker cp | tar -xO) ===
+    new Expectation('nonroot-user', 'sh', "-c 'docker cp ${containerName}:/etc/passwd - | tar -xO | grep ^nonroot'", 'nonroot:x:65532:65532:nonroot:/home/nonroot:/sbin/nologin'),
+    new Expectation('nonroot-group', 'sh', "-c 'docker cp ${containerName}:/etc/group - | tar -xO | grep ^nonroot'", 'nonroot:x:65532:'),
   ]
 }
 

--- a/expectations.groovy
+++ b/expectations.groovy
@@ -44,7 +44,7 @@ def containerExpectations(String containerName = 'iq-server-test') {
     new Expectation('request-log', 'sh', "-c 'docker cp ${containerName}:/var/log/nexus-iq-server/request.log - | tar -t | grep request.log'", 'request.log'),
 
     // === User/group verification (via docker cp | tar -xO) ===
-    new Expectation('nexus-user', 'sh', "-c 'docker cp ${containerName}:/etc/passwd - | tar -xO | grep ^nexus'", 'nexus:x:1000:1000:Nexus IQ user:/opt/sonatype/nexus-iq-server:/bin/false'),
+    new Expectation('nexus-user', 'sh', "-c 'docker cp ${containerName}:/etc/passwd - | tar -xO | grep ^nexus'", 'nexus:x:1000:1000:Nexus IQ user:/opt/sonatype/nexus-iq-server:/usr/sbin/nologin'),
     new Expectation('nexus-group', 'sh', "-c 'docker cp ${containerName}:/etc/group - | tar -xO | grep ^nexus'", 'nexus:x:1000:'),
   ]
 }

--- a/expectations.groovy
+++ b/expectations.groovy
@@ -31,6 +31,9 @@ def containerExpectations(String containerName = 'iq-server-test') {
     new Expectation('application-port', 'sh', "-c 'docker exec ${containerName} localcheck --port 8070 --path / && echo OK'", 'OK'),
     new Expectation('admin-port', 'sh', "-c 'docker exec ${containerName} localcheck --port 8071 && echo OK'", 'OK'),
 
+    // === Git executable verification ===
+    new Expectation('git-exists', 'sh', "-c 'docker exec ${containerName} git --version'", 'git version'),
+
     // === File existence (via docker cp | tar -t) ===
     new Expectation('launcher-exists', 'sh', "-c 'docker cp ${containerName}:/bin/launcher - | tar -t | grep launcher'", 'launcher'),
     new Expectation('tini-exists', 'sh', "-c 'docker cp ${containerName}:/sbin/tini-static - | tar -t | grep tini-static'", 'tini-static'),

--- a/expectations.groovy
+++ b/expectations.groovy
@@ -17,8 +17,10 @@
 import com.sonatype.jenkins.shared.Expectation
 
 def containerExpectations(String containerName = 'iq-server-test') {
-  // Get container PID for host-side /proc inspection
-  def pid = sh(script: "docker inspect --format '{{.State.Pid}}' ${containerName}", returnStdout: true).trim()
+  // docker inspect returns tini's PID (the container entrypoint). The actual java
+  // process is tini's child, so walk one level down to get the pid to inspect.
+  def tiniPid = sh(script: "docker inspect --format '{{.State.Pid}}' ${containerName}", returnStdout: true).trim()
+  def pid = sh(script: "ps -o pid= --ppid ${tiniPid} | head -1", returnStdout: true).trim()
 
   return [
     // === Process verification (via host /proc) ===
@@ -26,8 +28,10 @@ def containerExpectations(String containerName = 'iq-server-test') {
     new Expectation('java-opts-applied', 'sh', "-c 'cat /proc/${pid}/cmdline | tr \"\\0\" \" \"'", '-Dtest.java.opts=works'),
 
     // === Port checks (localcheck is built into base image) ===
-    new Expectation('application-port', 'docker', "exec ${containerName} localcheck --port 8070 --path /", ''),
-    new Expectation('admin-port', 'docker', "exec ${containerName} localcheck --port 8071", ''),
+    // Use host sh to chain && echo OK because localcheck succeeds silently and
+    // the Expectation class requires a non-empty expectedOutput.
+    new Expectation('application-port', 'sh', "-c 'docker exec ${containerName} localcheck --port 8070 --path / && echo OK'", 'OK'),
+    new Expectation('admin-port', 'sh', "-c 'docker exec ${containerName} localcheck --port 8071 && echo OK'", 'OK'),
 
     // === File existence (via docker cp | tar -t) ===
     new Expectation('launcher-exists', 'sh', "-c 'docker cp ${containerName}:/bin/launcher - | tar -t | grep launcher'", 'launcher'),

--- a/expectations.groovy
+++ b/expectations.groovy
@@ -17,15 +17,13 @@
 import com.sonatype.jenkins.shared.Expectation
 
 def containerExpectations(String containerName = 'iq-server-test') {
-  // docker inspect returns tini's PID (the container entrypoint). The actual java
-  // process is tini's child, so walk one level down to get the pid to inspect.
-  def tiniPid = sh(script: "docker inspect --format '{{.State.Pid}}' ${containerName}", returnStdout: true).trim()
-  def pid = sh(script: "ps -o pid= --ppid ${tiniPid} | head -1", returnStdout: true).trim()
-
   return [
-    // === Process verification (via host /proc) ===
-    new Expectation('java-process', 'sh', "-c 'cat /proc/${pid}/comm'", 'java'),
-    new Expectation('java-opts-applied', 'sh', "-c 'cat /proc/${pid}/cmdline | tr \"\\0\" \" \"'", '-Dtest.java.opts=works'),
+    // === Process verification ===
+    // docker top reads container processes via the docker daemon, so it works
+    // even when the Jenkins agent runs in its own PID namespace and can't see
+    // host PIDs directly.
+    new Expectation('java-process', 'sh', "-c 'docker top ${containerName} | grep -wq java && echo java'", 'java'),
+    new Expectation('java-opts-applied', 'sh', "-c 'docker top ${containerName} | grep -o -- -Dtest.java.opts=works'", '-Dtest.java.opts=works'),
 
     // === Port checks (localcheck is built into base image) ===
     // Use host sh to chain && echo OK because localcheck succeeds silently and

--- a/launcher.c
+++ b/launcher.c
@@ -32,49 +32,51 @@
  * Note that Java itself has no equivalent of execvp, which is why this is written in C.
  */
 int main(void) {
-    char *args[MAX_ARGS];
-    int arg_count = 0;
+  char *args[MAX_ARGS];
+  int arg_count = 0;
 
-    // Redirect stderr to log file
-    int stderr_fd = open("/var/log/nexus-iq-server/stderr.log",
-                         O_WRONLY | O_CREAT | O_APPEND, 0644);
-    if (stderr_fd >= 0) {
-        dup2(stderr_fd, STDERR_FILENO);
-        close(stderr_fd);
+  // Redirect stderr to log file
+  int stderr_fd = open("/var/log/nexus-iq-server/stderr.log",
+                       O_WRONLY | O_CREAT | O_APPEND, 0644);
+  if (stderr_fd >= 0) {
+    dup2(stderr_fd, STDERR_FILENO);
+    close(stderr_fd);
+  }
+
+  // Build argument list
+  args[arg_count++] = "java";
+  args[arg_count++] = "@/opt/sonatype/nexus-iq-server/jvm.options";
+
+  // Parse JAVA_OPTS - simple whitespace splitting (matches unquoted $JAVA_OPTS in bash)
+  char *opts_copy = NULL;
+  char *java_opts = getenv("JAVA_OPTS");
+  if (java_opts != NULL && java_opts[0] != '\0') {
+    opts_copy = strdup(java_opts);
+
+    if (opts_copy == NULL) {
+      fprintf(stderr, "Warning: failed to allocate memory for JAVA_OPTS, ignoring: %s\n", java_opts);
+    } else {
+      char *token = strtok(opts_copy, " \t\n");
+      while (token != NULL && arg_count < MAX_ARGS - 5) {
+        args[arg_count++] = token;
+        token = strtok(NULL, " \t\n");
+      }
     }
 
-    // Build argument list
-    args[arg_count++] = "java";
-    args[arg_count++] = "@/opt/sonatype/nexus-iq-server/jvm.options";
-
-    // Parse JAVA_OPTS - simple whitespace splitting (matches unquoted $JAVA_OPTS in bash)
-    char *opts_copy = NULL;
-    char *java_opts = getenv("JAVA_OPTS");
-    if (java_opts != NULL && java_opts[0] != '\0') {
-        opts_copy = strdup(java_opts);
-        if (opts_copy == NULL) {
-            fprintf(stderr, "Warning: failed to allocate memory for JAVA_OPTS, ignoring: %s\n", java_opts);
-        } else {
-            char *token = strtok(opts_copy, " \t\n");
-            while (token != NULL && arg_count < MAX_ARGS - 5) {
-                args[arg_count++] = token;
-                token = strtok(NULL, " \t\n");
-            }
-        }
-    }
-
-    // Add remaining arguments
-    args[arg_count++] = "-jar";
-    args[arg_count++] = "/opt/sonatype/nexus-iq-server/nexus-iq-server.jar";
-    args[arg_count++] = "server";
-    args[arg_count++] = "/etc/nexus-iq-server/config.yml";
-    args[arg_count] = NULL;
-
-    // Exec - replace this process with java
-    execvp("java", args);
-
-    // If we get here, exec failed
-    perror("execvp failed");
     free(opts_copy);
-    return 1;
+  }
+
+  // Add remaining arguments
+  args[arg_count++] = "-jar";
+  args[arg_count++] = "/opt/sonatype/nexus-iq-server/nexus-iq-server.jar";
+  args[arg_count++] = "server";
+  args[arg_count++] = "/etc/nexus-iq-server/config.yml";
+  args[arg_count] = NULL;
+
+  // Exec - replace this process with java
+  execvp("java", args);
+
+  // If we get here, exec failed
+  perror("execvp failed");
+  return 1;
 }

--- a/launcher.c
+++ b/launcher.c
@@ -1,17 +1,7 @@
 /*
- * Copyright (c) 2017-present Sonatype, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
+ * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
+ * "Sonatype" is a trademark of Sonatype, Inc.
  */
 
 #include <stdlib.h>

--- a/launcher.c
+++ b/launcher.c
@@ -72,8 +72,6 @@ int main(void) {
         token = strtok(NULL, " \t\n");
       }
     }
-
-    free(opts_copy);
   }
 
   // Add remaining arguments
@@ -83,10 +81,14 @@ int main(void) {
   args[arg_count++] = CONFIG_HOME "/config.yml";
   args[arg_count] = NULL;
 
-  // Exec - replace this process with java
+  // Exec - replace this process with java.
+  // opts_copy must stay allocated until exec: args[] entries from strtok() point
+  // into its buffer, so freeing earlier would leave execvp reading freed memory.
+  // On success execvp never returns; on failure we fall through and free below.
   execvp("java", args);
 
   // If we get here, exec failed
   perror("Could not start JVM for Nexus IQ Server");
+  free(opts_copy);
   return 1;
 }

--- a/launcher.c
+++ b/launcher.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <stdio.h>
 
 #define MAX_ARGS 128
 
@@ -38,9 +39,10 @@ int main(void) {
     args[arg_count++] = "@/opt/sonatype/nexus-iq-server/jvm.options";
 
     // Parse JAVA_OPTS - simple whitespace splitting (matches unquoted $JAVA_OPTS in bash)
+    char *opts_copy = NULL;
     char *java_opts = getenv("JAVA_OPTS");
     if (java_opts != NULL && java_opts[0] != '\0') {
-        char *opts_copy = strdup(java_opts);
+        opts_copy = strdup(java_opts);
         if (opts_copy != NULL) {
             char *token = strtok(opts_copy, " \t\n");
             while (token != NULL && arg_count < MAX_ARGS - 5) {
@@ -61,5 +63,7 @@ int main(void) {
     execvp("java", args);
 
     // If we get here, exec failed
+    perror("execvp failed");
+    free(opts_copy);
     return 1;
 }

--- a/launcher.c
+++ b/launcher.c
@@ -77,6 +77,6 @@ int main(void) {
   execvp("java", args);
 
   // If we get here, exec failed
-  perror("execvp failed");
+  perror("Could not start JVM for Nexus IQ Server");
   return 1;
 }

--- a/launcher.c
+++ b/launcher.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2017-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#define MAX_ARGS 128
+
+int main(void) {
+    char *args[MAX_ARGS];
+    int arg_count = 0;
+
+    // Redirect stderr to log file
+    int stderr_fd = open("/var/log/nexus-iq-server/stderr.log",
+                         O_WRONLY | O_CREAT | O_APPEND, 0644);
+    if (stderr_fd >= 0) {
+        dup2(stderr_fd, STDERR_FILENO);
+        close(stderr_fd);
+    }
+
+    // Build argument list
+    args[arg_count++] = "java";
+    args[arg_count++] = "@/opt/sonatype/nexus-iq-server/jvm.options";
+
+    // Parse JAVA_OPTS - simple whitespace splitting (matches unquoted $JAVA_OPTS in bash)
+    char *java_opts = getenv("JAVA_OPTS");
+    if (java_opts != NULL && java_opts[0] != '\0') {
+        char *opts_copy = strdup(java_opts);
+        if (opts_copy != NULL) {
+            char *token = strtok(opts_copy, " \t\n");
+            while (token != NULL && arg_count < MAX_ARGS - 5) {
+                args[arg_count++] = token;
+                token = strtok(NULL, " \t\n");
+            }
+        }
+    }
+
+    // Add remaining arguments
+    args[arg_count++] = "-jar";
+    args[arg_count++] = "/opt/sonatype/nexus-iq-server/nexus-iq-server.jar";
+    args[arg_count++] = "server";
+    args[arg_count++] = "/etc/nexus-iq-server/config.yml";
+    args[arg_count] = NULL;
+
+    // Exec - replace this process with java
+    execvp("java", args);
+
+    // If we get here, exec failed
+    return 1;
+}

--- a/launcher.c
+++ b/launcher.c
@@ -52,7 +52,9 @@ int main(void) {
     char *java_opts = getenv("JAVA_OPTS");
     if (java_opts != NULL && java_opts[0] != '\0') {
         opts_copy = strdup(java_opts);
-        if (opts_copy != NULL) {
+        if (opts_copy == NULL) {
+            fprintf(stderr, "Warning: failed to allocate memory for JAVA_OPTS, ignoring: %s\n", java_opts);
+        } else {
             char *token = strtok(opts_copy, " \t\n");
             while (token != NULL && arg_count < MAX_ARGS - 5) {
                 args[arg_count++] = token;

--- a/launcher.c
+++ b/launcher.c
@@ -33,10 +33,6 @@
 #define LOGS_HOME "/var/log/nexus-iq-server"
 #endif
 
-/* Stringify macro for path concatenation */
-#define STR(s) #s
-#define XSTR(s) STR(s)
-
 /*
  * This launcher exists because the distroless runtime image has no shell.
  * It replaces the previous shell-based start.sh and handles:
@@ -51,7 +47,7 @@ int main(void) {
   int arg_count = 0;
 
   // Redirect stderr to log file
-  int stderr_fd = open(XSTR(LOGS_HOME) "/stderr.log", O_WRONLY | O_CREAT | O_APPEND, 0644);
+  int stderr_fd = open(LOGS_HOME "/stderr.log", O_WRONLY | O_CREAT | O_APPEND, 0644);
   if (stderr_fd >= 0) {
     dup2(stderr_fd, STDERR_FILENO);
     close(stderr_fd);
@@ -59,7 +55,7 @@ int main(void) {
 
   // Build argument list
   args[arg_count++] = "java";
-  args[arg_count++] = "@" XSTR(IQ_HOME) "/jvm.options";
+  args[arg_count++] = "@" IQ_HOME "/jvm.options";
 
   // Parse JAVA_OPTS - simple whitespace splitting (matches unquoted $JAVA_OPTS in bash)
   char *opts_copy = NULL;
@@ -82,9 +78,9 @@ int main(void) {
 
   // Add remaining arguments
   args[arg_count++] = "-jar";
-  args[arg_count++] = XSTR(IQ_HOME) "/nexus-iq-server.jar";
+  args[arg_count++] = IQ_HOME "/nexus-iq-server.jar";
   args[arg_count++] = "server";
-  args[arg_count++] = XSTR(CONFIG_HOME) "/config.yml";
+  args[arg_count++] = CONFIG_HOME "/config.yml";
   args[arg_count] = NULL;
 
   // Exec - replace this process with java

--- a/launcher.c
+++ b/launcher.c
@@ -22,6 +22,13 @@
 
 #define MAX_ARGS 128
 
+/*
+ * This launcher exists because the distroless runtime image has no shell.
+ * It replaces the previous shell-based start.sh and handles:
+ *   1. Redirecting stderr to /var/log/nexus-iq-server/stderr.log
+ *   2. Parsing and injecting JAVA_OPTS environment variable
+ * Uses execvp() to replace itself with the JVM, preserving PID for signal handling.
+ */
 int main(void) {
     char *args[MAX_ARGS];
     int arg_count = 0;

--- a/launcher.c
+++ b/launcher.c
@@ -22,10 +22,25 @@
 
 #define MAX_ARGS 128
 
+/* Build-time paths (passed via -D flags to gcc) */
+#ifndef IQ_HOME
+#define IQ_HOME "/opt/sonatype/nexus-iq-server"
+#endif
+#ifndef CONFIG_HOME
+#define CONFIG_HOME "/etc/nexus-iq-server"
+#endif
+#ifndef LOGS_HOME
+#define LOGS_HOME "/var/log/nexus-iq-server"
+#endif
+
+/* Stringify macro for path concatenation */
+#define STR(s) #s
+#define XSTR(s) STR(s)
+
 /*
  * This launcher exists because the distroless runtime image has no shell.
  * It replaces the previous shell-based start.sh and handles:
- *   1. Redirecting stderr to /var/log/nexus-iq-server/stderr.log
+ *   1. Redirecting stderr to LOGS_HOME/stderr.log
  *   2. Parsing and injecting JAVA_OPTS environment variable
  *
  * Uses execvp() to replace itself with the JVM, preserving PID for signal handling.
@@ -36,8 +51,7 @@ int main(void) {
   int arg_count = 0;
 
   // Redirect stderr to log file
-  int stderr_fd = open("/var/log/nexus-iq-server/stderr.log",
-                       O_WRONLY | O_CREAT | O_APPEND, 0644);
+  int stderr_fd = open(XSTR(LOGS_HOME) "/stderr.log", O_WRONLY | O_CREAT | O_APPEND, 0644);
   if (stderr_fd >= 0) {
     dup2(stderr_fd, STDERR_FILENO);
     close(stderr_fd);
@@ -45,7 +59,7 @@ int main(void) {
 
   // Build argument list
   args[arg_count++] = "java";
-  args[arg_count++] = "@/opt/sonatype/nexus-iq-server/jvm.options";
+  args[arg_count++] = "@" XSTR(IQ_HOME) "/jvm.options";
 
   // Parse JAVA_OPTS - simple whitespace splitting (matches unquoted $JAVA_OPTS in bash)
   char *opts_copy = NULL;
@@ -68,9 +82,9 @@ int main(void) {
 
   // Add remaining arguments
   args[arg_count++] = "-jar";
-  args[arg_count++] = "/opt/sonatype/nexus-iq-server/nexus-iq-server.jar";
+  args[arg_count++] = XSTR(IQ_HOME) "/nexus-iq-server.jar";
   args[arg_count++] = "server";
-  args[arg_count++] = "/etc/nexus-iq-server/config.yml";
+  args[arg_count++] = XSTR(CONFIG_HOME) "/config.yml";
   args[arg_count] = NULL;
 
   // Exec - replace this process with java

--- a/launcher.c
+++ b/launcher.c
@@ -27,7 +27,9 @@
  * It replaces the previous shell-based start.sh and handles:
  *   1. Redirecting stderr to /var/log/nexus-iq-server/stderr.log
  *   2. Parsing and injecting JAVA_OPTS environment variable
+ *
  * Uses execvp() to replace itself with the JVM, preserving PID for signal handling.
+ * Note that Java itself has no equivalent of execvp, which is why this is written in C.
  */
 int main(void) {
     char *args[MAX_ARGS];


### PR DESCRIPTION
https://sonatype.atlassian.net/browse/CLM-39201
https://sonatype.atlassian.net/browse/CLM-39570

## Summary

Removes busybox from the IQ Docker image by replacing the shell-based `start.sh` script with a C launcher. This reduces attack surface and aligns with the distroless intent of the infosec hardened base images.

## Changes

- **C launcher** (`launcher.c`): Handles stderr redirection and JAVA_OPTS parsing, then execs the JVM directly
- **Dockerfile**: Removes busybox, adds gcc to compile launcher, updates CMD to use launcher
- **expectations.groovy**: Rewritten to use host-side `/proc` inspection and `docker cp` instead of shell commands inside container
- **Jenkinsfile/Jenkinsfile.release**: Added JAVA_OPTS test flag for verification
- **README.md**: Documented shell removal as breaking change

## Breaking Changes

- The runtime image no longer contains a shell (`/bin/sh`)
- Customers who relied on `docker exec -it <container> sh` will need to use `docker cp` or ephemeral debug containers for troubleshooting

## Testing

Build and test locally, or rely on CI.

## Related

- Depends on CLM-39066 (infosec base image migration)
- Prerequisite for CLM-39207 (FIPS-compliant Docker image)