### PR TITLE
CLM-39543 : Add skipMarkAsLatest parameter for hotfix/patch releases

### DIFF
--- a/Jenkinsfile.alpine.release
+++ b/Jenkinsfile.alpine.release
@@ -26,7 +26,8 @@ properties([
             description: 'The latest release of IQ Server to build the docker image'),
         string(name: 'sourceJob',
             defaultValue: 'insight/insight-brain/aggregate-release',
-            description: 'Job path to read artifacts from')
+            description: 'Job path to read artifacts from'),
+        booleanParam(name: 'skipMarkAsLatest', defaultValue: false, description: 'Skip: Tag as latest')
     ])
 ])
 
@@ -66,7 +67,7 @@ dockerizedBuildPipeline(
           iqStage: 'release')
     },
     deploy: {
-      pushImage(imageName)
+      pushImage(imageName, !params.skipMarkAsLatest)
     },
     onSuccess: {
       githubStatusUpdate('success')
@@ -78,7 +79,7 @@ dockerizedBuildPipeline(
 
 void updateIQServerVersionAndChecksum(String version, String checksum) {
   def dockerFile = readFile(file: 'Dockerfile.alpine')
-  def metaShortVersionRegex = /(release=")(\d\.\d{1,3}\.\d)(" \\)/
+  def metaShortVersionRegex = /(release=")(\d\.\d{1,3}\.\d)("\\)/
   def versionRegex = /(ARG IQ_SERVER_VERSION=)(\d\.\d{1,3}\.\d\-\d{2})/
   def shaRegex = /(ARG IQ_SERVER_SHA256=)([A-Fa-f0-9]{64})/
   dockerFile = dockerFile.replaceAll(metaShortVersionRegex,
@@ -102,7 +103,7 @@ void commitAndPushChanges(String version) {
   }
 }
 
-void pushImage(String imageName) {
+void pushImage(String imageName, boolean markAsLatest) {
   runSafely "mkdir -p '${env.WORKSPACE_TMP}/.dockerConfig'"
   runSafely "cp -n '${env.HOME}/.docker/config.json' '${env.WORKSPACE_TMP}/.dockerConfig' || true"
 
@@ -124,11 +125,15 @@ void pushImage(String imageName) {
       }
 
       runSafely "docker tag ${env.DOCKER_IMAGE_ID} ${imageName}:${env.VERSION}-alpine"
-      runSafely "docker tag ${env.DOCKER_IMAGE_ID} ${imageName}:latest-alpine"
+      if (markAsLatest) {
+        runSafely "docker tag ${env.DOCKER_IMAGE_ID} ${imageName}:latest-alpine"
+      }
 
       withCredentials([string(credentialsId: 'sonatype-password', variable: 'DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE')]) {
         runSafely "docker image push ${imageName}:${env.VERSION}-alpine"
-        runSafely "docker image push ${imageName}:latest-alpine"
+        if (markAsLatest) {
+          runSafely "docker image push ${imageName}:latest-alpine"
+        }
       }
 
       String response = runSafely("""curl -X POST https://hub.docker.com/v2/users/login/ \
@@ -142,7 +147,7 @@ void pushImage(String imageName) {
       readme = readme.replaceAll("(?s)<!--.*?-->", "")
       readme = readme.replace("\"", "\\\"")
       readme = readme.replace("\n", "\\n")
-      readme = readme.replace("\\\$", "\\\\\$")
+      readme = readme.replace("\\\$", "\\\$")
 
       httpRequest customHeaders: [[name: 'authorization', value: "JWT ${dockerHubApiToken}"]],
           acceptType: 'APPLICATION_JSON', contentType: 'APPLICATION_JSON', httpMode: 'PATCH',

--- a/Jenkinsfile.alpine.release
+++ b/Jenkinsfile.alpine.release
@@ -79,7 +79,7 @@ dockerizedBuildPipeline(
 
 void updateIQServerVersionAndChecksum(String version, String checksum) {
   def dockerFile = readFile(file: 'Dockerfile.alpine')
-  def metaShortVersionRegex = /(release=")(\d\.\d{1,3}\.\d)("\\)/
+  def metaShortVersionRegex = /(release=")(\d\.\d{1,3}\.\d)(" \\)/
   def versionRegex = /(ARG IQ_SERVER_VERSION=)(\d\.\d{1,3}\.\d\-\d{2})/
   def shaRegex = /(ARG IQ_SERVER_SHA256=)([A-Fa-f0-9]{64})/
   dockerFile = dockerFile.replaceAll(metaShortVersionRegex,
@@ -147,7 +147,7 @@ void pushImage(String imageName, boolean markAsLatest) {
       readme = readme.replaceAll("(?s)<!--.*?-->", "")
       readme = readme.replace("\"", "\\\"")
       readme = readme.replace("\n", "\\n")
-      readme = readme.replace("\\\$", "\\\$")
+      readme = readme.replace("\\\$", "\\\\\$")
 
       httpRequest customHeaders: [[name: 'authorization', value: "JWT ${dockerHubApiToken}"]],
           acceptType: 'APPLICATION_JSON', contentType: 'APPLICATION_JSON', httpMode: 'PATCH',

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -26,7 +26,8 @@ properties([
         description: 'The latest release of IQ Server to build the docker image'),
     string(name: 'sourceJob',
         defaultValue: 'insight/insight-brain/aggregate-release',
-        description: 'Job path to read artifacts from')
+        description: 'Job path to read artifacts from'),
+    booleanParam(name: 'skipMarkAsLatest', defaultValue: false, description: 'Skip: Tag as latest')
   ])
 ])
 
@@ -63,7 +64,7 @@ dockerizedBuildPipeline(
       iqStage: 'release')
   },
   deploy: {
-    pushImage(imageName)
+    pushImage(imageName, !params.skipMarkAsLatest)
   },
   postDeploy: {
     sonatypeZionGitConfig()
@@ -82,7 +83,7 @@ dockerizedBuildPipeline(
 
 void updateIQServerVersionAndChecksum(String version, String checksumX86_64, String checksumAarch) {
   def dockerFile = readFile(file: 'Dockerfile')
-  def metaShortVersionRegex = /(release=")(\d\.\d{1,3}\.\d)(" \\)/
+  def metaShortVersionRegex = /(release=")(\d\.\d{1,3}\.\d)("\\)/
   def versionRegex = /(ARG IQ_SERVER_VERSION=)(\d\.\d{1,3}\.\d\-\d{2})/
   def shaRegexAarch = /(ARG IQ_SERVER_SHA256_AARCH=)([A-Fa-f0-9]{64})/
   def shaRegexX64_64 = /(ARG IQ_SERVER_SHA256_X86_64=)([A-Fa-f0-9]{64})/
@@ -108,7 +109,7 @@ void commitAndPushChanges(String version) {
   }
 }
 
-void pushImage(String imageName) {
+void pushImage(String imageName, boolean markAsLatest) {
   runSafely "mkdir -p '${env.WORKSPACE_TMP}/.dockerConfig'"
   runSafely "cp -n '${env.HOME}/.docker/config.json' '${env.WORKSPACE_TMP}/.dockerConfig' || true"
 
@@ -129,6 +130,10 @@ void pushImage(String imageName) {
                    cp '${NEXUS_IQ_SERVER_DCT_GUN_KEY}' ${TRUST_DIR}/private
                    cp '${NEXUS_IQ_SERVER_DCT_ROOT_KEY}' ${TRUST_DIR}/private"""
       withSonatypeDockerRegistry() {
+        def tags = ["${env.VERSION}"]
+        if (markAsLatest) {
+          tags << "latest"
+        }
         runSafely """
         curl -L https://go.dev/dl/go1.23.3.linux-amd64.tar.gz | tar -xzf -
         export PATH=${env.PATH}:${env.WORKSPACE}/go/bin:${env.WORKSPACE}/bin
@@ -137,7 +142,7 @@ void pushImage(String imageName) {
         notary --help
         docker buildx create --use --driver-opt image=${sonatypeDockerRegistryId()}/moby/buildkit
         export OCI_REPO="sonatype/nexus-iq-server"
-        ./build_and_push_images.sh ${env.VERSION} latest
+        ./build_and_push_images.sh ${tags.join(' ')}
         """
       }
 

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -83,7 +83,7 @@ dockerizedBuildPipeline(
 
 void updateIQServerVersionAndChecksum(String version, String checksumX86_64, String checksumAarch) {
   def dockerFile = readFile(file: 'Dockerfile')
-  def metaShortVersionRegex = /(release=")(\d\.\d{1,3}\.\d)("\\)/
+  def metaShortVersionRegex = /(release=")(\d\.\d{1,3}\.\d)(" \\)/
   def versionRegex = /(ARG IQ_SERVER_VERSION=)(\d\.\d{1,3}\.\d\-\d{2})/
   def shaRegexAarch = /(ARG IQ_SERVER_SHA256_AARCH=)([A-Fa-f0-9]{64})/
   def shaRegexX64_64 = /(ARG IQ_SERVER_SHA256_X86_64=)([A-Fa-f0-9]{64})/

--- a/Jenkinsfile.slim.release
+++ b/Jenkinsfile.slim.release
@@ -26,7 +26,8 @@ properties([
         description: 'The latest release of IQ Server to build the docker image'),
     string(name: 'sourceJob',
         defaultValue: 'insight/insight-brain/aggregate-release',
-        description: 'Job path to read artifacts from')
+        description: 'Job path to read artifacts from'),
+    booleanParam(name: 'skipMarkAsLatest', defaultValue: false, description: 'Skip: Tag as latest')
   ])
 ])
 
@@ -64,7 +65,7 @@ dockerizedBuildPipeline(
       iqStage: 'release')
   },
   deploy: {
-    pushImage(imageName)
+    pushImage(imageName, !params.skipMarkAsLatest)
   },
   onSuccess: {
     githubStatusUpdate('success')
@@ -76,7 +77,7 @@ dockerizedBuildPipeline(
 
 void updateIQServerVersionAndChecksum(String version, String checksumX86_64, String checksumAarch) {
   def dockerFile = readFile(file: 'Dockerfile.slim')
-  def metaShortVersionRegex = /(release=")(\d\.\d{1,3}\.\d)(" \\)/
+  def metaShortVersionRegex = /(release=")(\d\.\d{1,3}\.\d)("\\)/
   def versionRegex = /(ARG IQ_SERVER_VERSION=)(\d\.\d{1,3}\.\d\-\d{2})/
   def shaRegexAarch = /(ARG IQ_SERVER_SHA256_AARCH=)([A-Fa-f0-9]{64})/
   def shaRegexX64_64 = /(ARG IQ_SERVER_SHA256_X86_64=)([A-Fa-f0-9]{64})/
@@ -102,7 +103,7 @@ void commitAndPushChanges(String version) {
   }
 }
 
-void pushImage(String imageName) {
+void pushImage(String imageName, boolean markAsLatest) {
   runSafely "mkdir -p '${env.WORKSPACE_TMP}/.dockerConfig'"
   runSafely "cp -n '${env.HOME}/.docker/config.json' '${env.WORKSPACE_TMP}/.dockerConfig' || true"
 
@@ -123,6 +124,10 @@ void pushImage(String imageName) {
                    cp '${NEXUS_IQ_SERVER_DCT_GUN_KEY}' ${TRUST_DIR}/private
                    cp '${NEXUS_IQ_SERVER_DCT_ROOT_KEY}' ${TRUST_DIR}/private"""
       withSonatypeDockerRegistry() {
+        def tags = ["${env.VERSION}-slim"]
+        if (markAsLatest) {
+          tags << "latest-slim"
+        }
         runSafely """
         curl -L https://go.dev/dl/go1.23.3.linux-amd64.tar.gz | tar -xzf -
         export PATH=${env.PATH}:${env.WORKSPACE}/go/bin:${env.WORKSPACE}/bin
@@ -132,7 +137,7 @@ void pushImage(String imageName) {
         docker buildx create --use --driver-opt image=${sonatypeDockerRegistryId()}/moby/buildkit
         export OCI_REPO="sonatype/nexus-iq-server"
         export DOCKERFILE="Dockerfile.slim"
-        ./build_and_push_images.sh "${env.VERSION}-slim" "latest-slim"
+        ./build_and_push_images.sh ${tags.join(' ')}
         """
       }
     }

--- a/Jenkinsfile.slim.release
+++ b/Jenkinsfile.slim.release
@@ -77,7 +77,7 @@ dockerizedBuildPipeline(
 
 void updateIQServerVersionAndChecksum(String version, String checksumX86_64, String checksumAarch) {
   def dockerFile = readFile(file: 'Dockerfile.slim')
-  def metaShortVersionRegex = /(release=")(\d\.\d{1,3}\.\d)("\\)/
+  def metaShortVersionRegex = /(release=")(\d\.\d{1,3}\.\d)(" \\)/
   def versionRegex = /(ARG IQ_SERVER_VERSION=)(\d\.\d{1,3}\.\d\-\d{2})/
   def shaRegexAarch = /(ARG IQ_SERVER_SHA256_AARCH=)([A-Fa-f0-9]{64})/
   def shaRegexX64_64 = /(ARG IQ_SERVER_SHA256_X86_64=)([A-Fa-f0-9]{64})/


### PR DESCRIPTION
Jira: https://sonatype.atlassian.net/browse/CLM-39543

## Problem

Currently, all IQ Server Docker images are automatically tagged as "latest" in Docker Hub. This behavior is undesirable for hotfix/patch releases where the version should be available but NOT marked as the "latest" version.

## Solution

Add a `skipMarkAsLatest` parameter (default: `false`) to allow opting out of "latest" tagging for hotfix/patch releases.

## Changes

### Jenkinsfile.release (Standard Docker)
- Add `skipMarkAsLatest` parameter (default: `false`)
- Modify `pushImage` function to conditionally include "latest" tag

### Jenkinsfile.alpine.release
- Add `skipMarkAsLatest` parameter (default: `false`)
- Modify `pushImage` function to conditionally tag/push "latest-alpine"

### Jenkinsfile.slim.release
- Add `skipMarkAsLatest` parameter (default: `false`)
- Modify `pushImage` function to conditionally include "latest-slim" tag

## Usage

### Regular Release (default behavior)
No parameter changes needed - images will be tagged with both version and "latest".

### Hotfix/Patch Release
Set `skipMarkAsLatest = true` when triggering the Docker release jobs.

**Result:**
- ✅ Docker images tagged with version only (no "latest")
- ✅ Existing "latest" tags remain unchanged
- ✅ Images still available for download

## Backward Compatibility

All parameters default to `false` (i.e., mark as latest), so existing pipeline runs will behave exactly as before.

## Related PR

insight-brain PR: https://github.com/sonatype/insight-brain/pull/15668

## Test Plan

- [ ] Verify regular release (`skipMarkAsLatest=false`) marks Docker images as "latest"
- [ ] Verify hotfix release (`skipMarkAsLatest=true`) does NOT mark Docker images as "latest"

🤖 Generated with [Claude Code](https://claude.com/claude-code)