### PR TITLE
Revert 1.199.1 version update - restore 1.202.1 as latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6 AS builder
 ARG TEMP="/tmp/work"
 # Build parameters
-ARG IQ_SERVER_VERSION=1.199.1-01
-ARG IQ_SERVER_SHA256_AARCH=5174d2399d3b59090fb6acb275dedc51fe152df1278399015fe9d091ae1c35c4
-ARG IQ_SERVER_SHA256_X86_64=6819a5807ec68db9a232faa3eff0f8461059c82062ab81ce769ae4a5fdb14cee
+ARG IQ_SERVER_VERSION=1.202.1-01
+ARG IQ_SERVER_SHA256_AARCH=f45baed630e6c14717711b95a4865637f1fe8b1041da71d1585938928dffcea0
+ARG IQ_SERVER_SHA256_X86_64=e03505b3767416664210b6f4bc07265988b86f5280443ed0e5a96730397138ca
 ARG SONATYPE_WORK="/sonatype-work"
 
 # hadolint ignore=DL3041,DL3040
@@ -54,7 +54,7 @@ RUN sha256sum -c nexus-iq-server.tar.gz.sha256 \
 # hadolint ignore=DL3026
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
 
-ARG IQ_SERVER_VERSION=1.199.1-01
+ARG IQ_SERVER_VERSION=1.202.1-01
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
 ARG SONATYPE_WORK="/sonatype-work"
 ARG CONFIG_HOME="/etc/nexus-iq-server"
@@ -67,7 +67,7 @@ LABEL name="Nexus IQ Server image" \
   maintainer="Sonatype <support@sonatype.com>" \
   vendor=Sonatype \
   version="${IQ_SERVER_VERSION}" \
-  release="1.199.1" \
+  release="1.202.1" \
   url="https://www.sonatype.com" \
   summary="The Nexus IQ Server" \
   description="Nexus IQ Server is a policy engine powered by precise intelligence on open source components. \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -18,8 +18,8 @@
 FROM sonatype.repo.sonatype.app/docker-all/alpine:3 AS builder
 ARG TEMP="/tmp/work"
 # Build parameters
-ARG IQ_SERVER_VERSION=1.199.1-01
-ARG IQ_SERVER_SHA256=20661c5dd5ea20e4713210309442e501a5465c906839858ac47a0d868b42964e
+ARG IQ_SERVER_VERSION=1.202.1-01
+ARG IQ_SERVER_SHA256=4dbf46c92860b0a824e1fab7de8eec5ef950b12f8e1d194902b8fcac6ee41f17
 ARG SONATYPE_WORK="/sonatype-work"
 
 # hadolint ignore=DL3018
@@ -46,7 +46,7 @@ RUN sha256sum -c nexus-iq-server.tar.gz.sha256 \
 # hadolint ignore=DL3026
 FROM sonatype.repo.sonatype.app/docker-all/alpine:3
 
-ARG IQ_SERVER_VERSION=1.199.1-01
+ARG IQ_SERVER_VERSION=1.202.1-01
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
 ARG SONATYPE_WORK="/sonatype-work"
 ARG CONFIG_HOME="/etc/nexus-iq-server"
@@ -59,7 +59,7 @@ LABEL name="Nexus IQ Server image" \
   maintainer="Sonatype <support@sonatype.com>" \
   vendor=Sonatype \
   version="${IQ_SERVER_VERSION}" \
-  release="1.199.1" \
+  release="1.202.1" \
   url="https://www.sonatype.com" \
   summary="The Nexus IQ Server" \
   description="Nexus IQ Server is a policy engine powered by precise intelligence on open source components. \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -18,9 +18,9 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6 AS builder
 ARG TEMP="/tmp/work"
 # Build parameters
-ARG IQ_SERVER_VERSION=1.199.1-01
-ARG IQ_SERVER_SHA256_AARCH=5174d2399d3b59090fb6acb275dedc51fe152df1278399015fe9d091ae1c35c4
-ARG IQ_SERVER_SHA256_X86_64=6819a5807ec68db9a232faa3eff0f8461059c82062ab81ce769ae4a5fdb14cee
+ARG IQ_SERVER_VERSION=1.202.1-01
+ARG IQ_SERVER_SHA256_AARCH=f45baed630e6c14717711b95a4865637f1fe8b1041da71d1585938928dffcea0
+ARG IQ_SERVER_SHA256_X86_64=e03505b3767416664210b6f4bc07265988b86f5280443ed0e5a96730397138ca
 ARG SONATYPE_WORK="/sonatype-work"
 
 # hadolint ignore=DL3041,DL3040
@@ -54,7 +54,7 @@ RUN sha256sum -c nexus-iq-server.tar.gz.sha256 \
 # hadolint ignore=DL3026
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
 
-ARG IQ_SERVER_VERSION=1.199.1-01
+ARG IQ_SERVER_VERSION=1.202.1-01
 ARG IQ_HOME="/opt/sonatype/nexus-iq-server"
 ARG SONATYPE_WORK="/sonatype-work"
 ARG CONFIG_HOME="/etc/nexus-iq-server"
@@ -67,7 +67,7 @@ LABEL name="Nexus IQ Server image" \
   maintainer="Sonatype <support@sonatype.com>" \
   vendor=Sonatype \
   version="${IQ_SERVER_VERSION}" \
-  release="1.199.1" \
+  release="1.202.1" \
   url="https://www.sonatype.com" \
   summary="The Nexus IQ Server" \
   description="Nexus IQ Server is a policy engine powered by precise intelligence on open source components. \


### PR DESCRIPTION
## Summary
This PR reverts the incorrect version update from 1.202.1-01 to 1.199.1-01 that was pushed to main.

## Problem
During the 1.199.1 patch release process, the `docker-nexus-iq-server` repository was incorrectly updated to point to 1.199.1 instead of keeping the latest version (1.202.1).

The commits being reverted:
- `51d32f4` - Update IQ Server to 1.199.1-01 (Dockerfile)
- `582e2c6` - Update IQ Server to 1.199.1-01 (Dockerfile.alpine)
- `8b64e0f` - Update IQ Server to 1.199.1-01 (Dockerfile.slim)

## Root Cause
The Docker publishing stages in the Release IQ Server pipeline update the `docker-nexus-iq-server` repository with the version being released, even when `skipMarkAsLatest=true`. For patch releases of previous versions, this incorrectly downgrades the Dockerfiles to an older version.

## Fix
- Revert to commit `cc00b3f` which has the correct version (1.202.1-01)
- The pipeline needs to be updated to skip the version update when `skipMarkAsLatest=true`

## Verification
- Dockerfiles should show `IQ_SERVER_VERSION=1.202.1-01`
- This is the correct latest version

🤖 Generated with [Claude Code](https://claude.com/claude-code)