### PR TITLE
Skip git commit for patch releases when skipMarkAsLatest=true

### DIFF
--- a/Jenkinsfile.alpine.release
+++ b/Jenkinsfile.alpine.release
@@ -42,7 +42,7 @@ dockerizedBuildPipeline(
       version = getVersionFromBuildName(env.releaseBuild_NAME)
       checksum = readBuildArtifact(params.sourceJob, env.releaseBuild_NUMBER, "artifacts/nexus-iq-server-${version}-linux_musl-x86_64.tgz.sha256").trim()
       updateIQServerVersionAndChecksum(version, checksum)
-      commitAndPushChanges(version)
+      commitAndPushChanges(version, params.skipMarkAsLatest)
     },
     pathToDockerfile: './Dockerfile.alpine',
     setVersion: {
@@ -90,7 +90,13 @@ void updateIQServerVersionAndChecksum(String version, String checksum) {
   writeFile(file: 'Dockerfile.alpine', text: dockerFile)
 }
 
-void commitAndPushChanges(String version) {
+void commitAndPushChanges(String version, boolean skipMarkAsLatest) {
+  if (skipMarkAsLatest) {
+    // Skip committing and pushing changes for patch/hotfix releases of older versions
+    // The main branch should always reflect the latest released version
+    echo "Skipping git commit and push because skipMarkAsLatest=true (patch/hotfix release)"
+    return
+  }
   runSafely 'git config --global push.default simple'
   sonatypeZionGitConfig()
   sshagent(credentials: [sonatypeZionCredentialsId()]) {

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -44,7 +44,7 @@ dockerizedBuildPipeline(
     checksumX86_64 = readBuildArtifact(params.sourceJob, env.releaseBuild_NUMBER, "artifacts/nexus-iq-server-${version}-linux-x86_64.tgz.sha256").trim()
     checksumAarch = readBuildArtifact(params.sourceJob, env.releaseBuild_NUMBER, "artifacts/nexus-iq-server-${version}-linux-aarch_64.tgz.sha256").trim()
     updateIQServerVersionAndChecksum(version, checksumX86_64, checksumAarch)
-    commitAndPushChanges(version)
+    commitAndPushChanges(version, params.skipMarkAsLatest)
   },
   setVersion: {
     env['VERSION'] = version.split('-')[0]
@@ -96,7 +96,13 @@ void updateIQServerVersionAndChecksum(String version, String checksumX86_64, Str
   writeFile(file: 'Dockerfile', text: dockerFile)
 }
 
-void commitAndPushChanges(String version) {
+void commitAndPushChanges(String version, boolean skipMarkAsLatest) {
+  if (skipMarkAsLatest) {
+    // Skip committing and pushing changes for patch/hotfix releases of older versions
+    // The main branch should always reflect the latest released version
+    echo "Skipping git commit and push because skipMarkAsLatest=true (patch/hotfix release)"
+    return
+  }
   runSafely 'git config --global push.default simple'
   sonatypeZionGitConfig()
   sshagent(credentials: [sonatypeZionCredentialsId()]) {

--- a/Jenkinsfile.slim.release
+++ b/Jenkinsfile.slim.release
@@ -44,7 +44,7 @@ dockerizedBuildPipeline(
     checksumX86_64 = readBuildArtifact(params.sourceJob, env.releaseBuild_NUMBER, "artifacts/nexus-iq-server-${version}-linux-x86_64.tgz.sha256").trim()
     checksumAarch = readBuildArtifact(params.sourceJob, env.releaseBuild_NUMBER, "artifacts/nexus-iq-server-${version}-linux-aarch_64.tgz.sha256").trim()
     updateIQServerVersionAndChecksum(version, checksumX86_64, checksumAarch)
-    commitAndPushChanges(version)
+    commitAndPushChanges(version, params.skipMarkAsLatest)
   },
   pathToDockerfile: './Dockerfile.slim',
   setVersion: {
@@ -90,7 +90,13 @@ void updateIQServerVersionAndChecksum(String version, String checksumX86_64, Str
   writeFile(file: 'Dockerfile.slim', text: dockerFile)
 }
 
-void commitAndPushChanges(String version) {
+void commitAndPushChanges(String version, boolean skipMarkAsLatest) {
+  if (skipMarkAsLatest) {
+    // Skip committing and pushing changes for patch/hotfix releases of older versions
+    // The main branch should always reflect the latest released version
+    echo "Skipping git commit and push because skipMarkAsLatest=true (patch/hotfix release)"
+    return
+  }
   runSafely 'git config --global push.default simple'
   sonatypeZionGitConfig()
   sshagent(credentials: [sonatypeZionCredentialsId()]) {


### PR DESCRIPTION
## Summary
When `skipMarkAsLatest=true` (patch/hotfix release of older versions), the Dockerfile should NOT be updated in the main branch.

## Problem
The `commitAndPushChanges()` function in the Docker release Jenkinsfiles unconditionally commits and pushes the Dockerfile version updates to `main`, regardless of the `skipMarkAsLatest` parameter.

This caused the 1.199.1 patch release to incorrectly update the Dockerfiles from 1.202.1 (the latest) to 1.199.1 (the older patch version).

## Root Cause
- `skipMarkAsLatest` only affected whether to add the `latest` tag when pushing Docker images
- It did NOT skip the Dockerfile version update and commit to `main`

## Fix
Modified `commitAndPushChanges()` in all three affected Jenkinsfiles to:
1. Accept a `skipMarkAsLatest` parameter
2. Return early without making git changes when `skipMarkAsLatest=true`
3. Log why the commit is being skipped

## Affected Files
- `Jenkinsfile.release` (standard Docker image)
- `Jenkinsfile.slim.release` (slim Docker image)
- `Jenkinsfile.alpine.release` (alpine Docker image)

**Note:** `Jenkinsfile.rh.release` was not modified because it doesn't use `commitAndPushChanges()` and doesn't commit to the repository.

## Related
- Revert PR: #185 (reverts the incorrect version update)
- Confluence doc: https://sonatype.atlassian.net/wiki/spaces/SP/pages/2243264521 (Patch Release Process)

🤖 Generated with [Claude Code](https://claude.com/claude-code)