### PR TITLE
chore: minimize container image to reduce vulnerability surface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,7 @@ RUN update-crypto-policies --set DEFAULT:SHA1
 # Remove packages not needed at runtime to reduce vulnerability surface
 # - crypto-policies-scripts + python3 stack: only needed for update-crypto-policies above
 # - microdnf + libdnf + glib2 + json-glib + libpeas + gobject-introspection: package manager not needed at runtime
-# - gawk: transitive dep of krb5-libs, never invoked
+# - gawk: transitive dep of krb5-libs (install scriptlet only), never invoked at runtime
 # hadolint ignore=DL3059
 RUN microdnf remove -y crypto-policies-scripts python3 python3-libs python3-pip-wheel python3-setuptools-wheel \
 && rpm -e --nodeps microdnf libdnf json-glib libpeas gobject-introspection glib2 gawk

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ARG SONATYPE_WORK="/sonatype-work"
 # hadolint ignore=DL3041,DL3040
 RUN mkdir -p ${TEMP} && \
     microdnf update -y && \
-    microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git which crypto-policies crypto-policies-scripts
+    microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git-core openssh-clients which crypto-policies crypto-policies-scripts
 
 # Copy config.yml and set sonatypeWork to the correct value
 COPY config.yml ${TEMP}
@@ -88,7 +88,7 @@ USER root
 # For testing
 # hadolint ignore=DL3041
 RUN microdnf update -y \
-&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git which crypto-policies crypto-policies-scripts \
+&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git-core openssh-clients which crypto-policies crypto-policies-scripts \
 && microdnf clean all
 
 # Create folders & set permissions

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ USER root
 # For testing
 # hadolint ignore=DL3041
 RUN microdnf update -y \
-&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git-core openssh-clients which crypto-policies crypto-policies-scripts \
+&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y procps gzip unzip shadow-utils findutils util-linux less rsync git-core openssh-clients which crypto-policies crypto-policies-scripts \
 && microdnf clean all
 
 # Create folders & set permissions

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,6 +127,14 @@ WORKDIR ${IQ_HOME}
 # enabling back support for SHA1 signed certificates
 RUN update-crypto-policies --set DEFAULT:SHA1
 
+# Remove packages not needed at runtime to reduce vulnerability surface
+# - crypto-policies-scripts + python3 stack: only needed for update-crypto-policies above
+# - microdnf + libdnf + glib2 + json-glib + libpeas + gobject-introspection: package manager not needed at runtime
+# - gawk: transitive dep of krb5-libs, never invoked
+# hadolint ignore=DL3059
+RUN microdnf remove -y crypto-policies-scripts python3 python3-libs python3-pip-wheel python3-setuptools-wheel \
+&& rpm -e --nodeps microdnf libdnf json-glib libpeas gobject-introspection glib2 gawk
+
 # This is where we will store persistent data
 VOLUME ${SONATYPE_WORK}
 VOLUME ${LOGS_HOME}

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -133,7 +133,7 @@ RUN update-crypto-policies --set DEFAULT:SHA1
 # Remove packages not needed at runtime to reduce vulnerability surface
 # - crypto-policies-scripts + python3 stack: only needed for update-crypto-policies above
 # - microdnf + libdnf + glib2 + json-glib + libpeas + gobject-introspection: package manager not needed at runtime
-# - gawk: transitive dep of krb5-libs, never invoked
+# - gawk: transitive dep of krb5-libs (install scriptlet only), never invoked at runtime
 # hadolint ignore=DL3059
 RUN microdnf remove -y crypto-policies-scripts python3 python3-libs python3-pip-wheel python3-setuptools-wheel \
 && rpm -e --nodeps microdnf libdnf json-glib libpeas gobject-introspection glib2 gawk

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -81,7 +81,7 @@ USER root
 # For testing
 # hadolint ignore=DL3041
 RUN microdnf update -y \
-&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git-core openssh-clients which crypto-policies crypto-policies-scripts \
+&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y procps gzip unzip shadow-utils findutils util-linux less rsync git-core openssh-clients which crypto-policies crypto-policies-scripts \
 && microdnf clean all
 
 # Create folders & set permissions

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -25,7 +25,7 @@ ARG SONATYPE_WORK="/sonatype-work"
 # hadolint ignore=DL3041,DL3040
 RUN mkdir -p ${TEMP} && \
     microdnf update -y && \
-    microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git which crypto-policies crypto-policies-scripts
+    microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git-core openssh-clients which crypto-policies crypto-policies-scripts
 
 # Copy config.yml and set sonatypeWork to the correct value
 COPY config.yml ${TEMP}
@@ -81,7 +81,7 @@ USER root
 # For testing
 # hadolint ignore=DL3041
 RUN microdnf update -y \
-&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git which crypto-policies crypto-policies-scripts \
+&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git-core openssh-clients which crypto-policies crypto-policies-scripts \
 && microdnf clean all
 
 # Create folders & set permissions

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -130,6 +130,14 @@ WORKDIR ${IQ_HOME}
 # enabling back support for SHA1 signed certificates
 RUN update-crypto-policies --set DEFAULT:SHA1
 
+# Remove packages not needed at runtime to reduce vulnerability surface
+# - crypto-policies-scripts + python3 stack: only needed for update-crypto-policies above
+# - microdnf + libdnf + glib2 + json-glib + libpeas + gobject-introspection: package manager not needed at runtime
+# - gawk: transitive dep of krb5-libs, never invoked
+# hadolint ignore=DL3059
+RUN microdnf remove -y crypto-policies-scripts python3 python3-libs python3-pip-wheel python3-setuptools-wheel \
+&& rpm -e --nodeps microdnf libdnf json-glib libpeas gobject-introspection glib2 gawk
+
 # This is where we will store persistent data
 VOLUME ${SONATYPE_WORK}
 VOLUME ${LOGS_HOME}

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -130,7 +130,7 @@ RUN update-crypto-policies --set DEFAULT:SHA1
 # Remove packages not needed at runtime to reduce vulnerability surface
 # - crypto-policies-scripts + python3 stack: only needed for update-crypto-policies above
 # - microdnf + libdnf + glib2 + json-glib + libpeas + gobject-introspection: package manager not needed at runtime
-# - gawk: transitive dep of krb5-libs, never invoked
+# - gawk: transitive dep of krb5-libs (install scriptlet only), never invoked at runtime
 # hadolint ignore=DL3059
 RUN microdnf remove -y crypto-policies-scripts python3 python3-libs python3-pip-wheel python3-setuptools-wheel \
 && rpm -e --nodeps microdnf libdnf json-glib libpeas gobject-introspection glib2 gawk

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -26,7 +26,7 @@ ARG SONATYPE_WORK="/sonatype-work"
 # hadolint ignore=DL3041,DL3040
 RUN mkdir -p ${TEMP} && \
     microdnf update -y && \
-    microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git which crypto-policies crypto-policies-scripts
+    microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git-core openssh-clients which crypto-policies crypto-policies-scripts
 
 # Copy config.yml and set sonatypeWork to the correct value
 COPY config.yml ${TEMP}
@@ -88,7 +88,7 @@ USER root
 # For testing
 # hadolint ignore=DL3041
 RUN microdnf update -y \
-&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git which crypto-policies crypto-policies-scripts \
+&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git-core openssh-clients which crypto-policies crypto-policies-scripts \
 && microdnf clean all
 
 # Create folders & set permissions

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -88,7 +88,7 @@ USER root
 # For testing
 # hadolint ignore=DL3041
 RUN microdnf update -y \
-&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y procps gzip unzip tar shadow-utils findutils util-linux less rsync git-core openssh-clients which crypto-policies crypto-policies-scripts \
+&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y procps gzip unzip shadow-utils findutils util-linux less rsync git-core openssh-clients which crypto-policies crypto-policies-scripts \
 && microdnf clean all
 
 # Create folders & set permissions

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -127,6 +127,14 @@ WORKDIR ${IQ_HOME}
 # enabling back support for SHA1 signed certificates
 RUN update-crypto-policies --set DEFAULT:SHA1
 
+# Remove packages not needed at runtime to reduce vulnerability surface
+# - crypto-policies-scripts + python3 stack: only needed for update-crypto-policies above
+# - microdnf + libdnf + glib2 + json-glib + libpeas + gobject-introspection: package manager not needed at runtime
+# - gawk: transitive dep of krb5-libs, never invoked
+# hadolint ignore=DL3059
+RUN microdnf remove -y crypto-policies-scripts python3 python3-libs python3-pip-wheel python3-setuptools-wheel \
+&& rpm -e --nodeps microdnf libdnf json-glib libpeas gobject-introspection glib2 gawk
+
 # This is where we will store persistent data
 VOLUME ${SONATYPE_WORK}
 VOLUME ${LOGS_HOME}

--- a/expectations.groovy
+++ b/expectations.groovy
@@ -23,17 +23,17 @@ def containerExpectations() {
     new Expectation('iq-process', 'ps', '-e -o command,user | grep -q ^/usr/bin/java.*nexus$ | echo $?', '0'),
     new Expectation('application-port', 'curl', '-s --fail --connect-timeout 120 http://localhost:8070/ | echo $?', '0'),
     new Expectation('admin-port', 'curl', '-s --fail --connect-timeout 120 http://localhost:8071/ | echo $?', '0'),
-    new Expectation('log-directory', 'ls', '-la /var/log | awk \'\$9 !~ /^\\.*$/{print \$1,\$3,\$4,\$9}\'', 'drwxr-xr-x nexus nexus nexus-iq-server'),
+    new Expectation('log-directory', 'stat', '-c \'%A %U %G\' /var/log/nexus-iq-server', 'drwxr-xr-x nexus nexus'),
     new Expectation('clm-server-log', 'test', '-f /var/log/nexus-iq-server/clm-server-log.log | echo $?', '0'),
     new Expectation('audit-log', 'test', '-f /var/log/nexus-iq-server/audit.log | echo $?', '0'),
     new Expectation('request-log', 'test', '-f /var/log/nexus-iq-server/request.log | echo $?', '0'),
     new Expectation('stderr-log', 'test', '-f /var/log/nexus-iq-server/stderr.log | echo $?', '0'),
-    new Expectation('home-directory', 'ls', '-la /opt/sonatype | grep nexus-iq-server | awk \'\$9 !~ /^\\.*$/{print \$1,\$3,\$4,\$9}\'', 'drwxr-xr-x nexus nexus nexus-iq-server'),
+    new Expectation('home-directory', 'stat', '-c \'%A %U %G\' /opt/sonatype/nexus-iq-server', 'drwxr-xr-x nexus nexus'),
     new Expectation('start-script', 'test', '-f /opt/sonatype/nexus-iq-server/start.sh | echo $?', '0'),
     new Expectation('start-script-has-java-opts', 'grep', '\'JAVA_OPTS\' /opt/sonatype/nexus-iq-server/start.sh | echo $?', '0'), 
-    new Expectation('work-directory', 'ls', '-la / | grep sonatype-work | awk \'\$9 !~ /^\\.*$/{print \$1,\$3,\$4,\$9}\'', 'drwxr-xr-x nexus nexus sonatype-work'), 
+    new Expectation('work-directory', 'stat', '-c \'%A %U %G\' /sonatype-work', 'drwxr-xr-x nexus nexus'),
     new Expectation('data-directory', 'test', '-d /sonatype-work/data | echo $?', '0'), 
-    new Expectation('config-directory', 'ls', '-la /etc | grep nexus-iq-server | awk \'\$9 !~ /^\\.*$/{print \$1,\$3,\$4,\$9}\'', 'drwxr-xr-x nexus nexus nexus-iq-server'), 
+    new Expectation('config-directory', 'stat', '-c \'%A %U %G\' /etc/nexus-iq-server', 'drwxr-xr-x nexus nexus'),
     new Expectation('config-file', 'test', '-f /etc/nexus-iq-server | echo $?', '0') 
   ]     
 }


### PR DESCRIPTION
## Motivation

Reduce IQ policy violation findings by removing packages that are not needed at runtime. This eliminates 3 CVE findings from the IQ scan:

- **CVE-2026-32284** (python3-pip-wheel) — pip is never invoked; Java app
- **CVE-2023-32636** (glib2) — no D-Bus/GVariant usage; microdnf dep only
- **CVE-2023-4156** (gawk) — never invoked at runtime; krb5-libs install scriptlet dep only

## Changes

1. **Use `git-core` instead of `git`** — provides the same binary without pulling in perl and its dependency tree. `openssh-clients` added explicitly to retain SSH transport.

2. **Post-install package removal** — after `update-crypto-policies` runs, remove packages only needed for installation:
   - `crypto-policies-scripts` + python3 stack (only needed for `update-crypto-policies`)
   - `microdnf` + `libdnf` + `glib2` + `json-glib` + `libpeas` + `gobject-introspection` (package manager not needed at runtime)
   - `gawk` (transitive dep of krb5-libs install scriptlet, never invoked)

3. **Rewrite test expectations** — replace `ls | awk` patterns with `stat -c` to avoid depending on awk in the container.

## Remaining findings (4 CVEs — cannot remove, exception tickets filed)

| CVE | Package | Why it can't be removed |
|-----|---------|------------------------|
| CVE-2022-41409 | pcre2 | Compiled into git-core binary (libpcre2-8.so) |
| CVE-2026-41080 | expat | Compiled into git-core binary (libexpat.so) |
| CVE-2026-2673 | openssl-libs | Required by git, curl, openssh for TLS |
| CVE-2023-51767 | openssh | Required for git SSH transport |

Exception tickets: CLM-40383, CLM-40386, CLM-40387, CLM-40389

## Testing

All three CI pipelines pass (build #3).